### PR TITLE
Add transparency while plotting a result that is not over the whole mesh

### DIFF
--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -284,8 +284,8 @@ class Plotter:
 
         val_field = mesh_to_compute["result"][val_mask]
 
-        plotter.add_mesh(nan_grid, scalars = nan_field, 
-                         opacity = 0.3, nan_color = "w", 
+        plotter.add_mesh(nan_grid, scalars = nan_field,
+                         opacity = 0.3, nan_color = "w",
                          show_edges = False)
         plotter.add_mesh(val_grid, scalars = val_field, **kwargs)
 

--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -271,7 +271,21 @@ class Plotter:
         kwargs.setdefault("show_edges", True)
         kwargs.setdefault("nan_color", "grey")
         kwargs.setdefault("stitle", name)
-        plotter.add_mesh(mesh.grid, scalars=overall_data, **kwargs)
+        
+        # plotter.add_mesh(mesh.grid, scalars=overall_data, **kwargs)
+        
+        mesh.grid["result"] = overall_data
+        mesh_to_compute = mesh.grid.extract_surface()
+        nan_mask = np.isnan(mesh_to_compute["result"])
+        val_mask = ~np.isnan(mesh_to_compute["result"])
+        nan_grid = mesh_to_compute.extract_points(nan_mask, adjacent_cells=False)
+        val_grid = mesh_to_compute.extract_points(val_mask, adjacent_cells=False)
+        nan_field = mesh_to_compute["result"][nan_mask]
+
+        val_field = mesh_to_compute["result"][val_mask]
+
+        plotter.add_mesh(nan_grid, scalars = nan_field, opacity = 0.3, nan_color = "w", show_edges = False)
+        plotter.add_mesh(val_grid, scalars = val_field, **kwargs)
 
         if background is not None:
             plotter.set_background(background)

--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -279,11 +279,11 @@ class Plotter:
         nan_mask = np.isnan(mesh_to_compute["result"])
         if len(nan_mask.shape) > 1:
             if (nan_mask.shape[1] > 1):
-                nan_mask = nan_mask[:,1]
+                nan_mask = nan_mask[:, 1]
         val_mask = ~np.isnan(mesh_to_compute["result"])
         if len(val_mask.shape) > 1:
             if (val_mask.shape[1] > 1):
-                val_mask = val_mask[:,1]
+                val_mask = val_mask[:, 1]
         nan_grid = mesh_to_compute.extract_points(nan_mask, adjacent_cells=False)
         val_grid = mesh_to_compute.extract_points(val_mask, adjacent_cells=False)
         nan_field = mesh_to_compute["result"][nan_mask]

--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -271,9 +271,9 @@ class Plotter:
         kwargs.setdefault("show_edges", True)
         kwargs.setdefault("nan_color", "grey")
         kwargs.setdefault("stitle", name)
-        
+
         # plotter.add_mesh(mesh.grid, scalars=overall_data, **kwargs)
-        
+
         mesh.grid["result"] = overall_data
         mesh_to_compute = mesh.grid.extract_surface()
         nan_mask = np.isnan(mesh_to_compute["result"])
@@ -284,7 +284,9 @@ class Plotter:
 
         val_field = mesh_to_compute["result"][val_mask]
 
-        plotter.add_mesh(nan_grid, scalars = nan_field, opacity = 0.3, nan_color = "w", show_edges = False)
+        plotter.add_mesh(nan_grid, scalars = nan_field, 
+                         opacity = 0.3, nan_color = "w", 
+                         show_edges = False)
         plotter.add_mesh(val_grid, scalars = val_field, **kwargs)
 
         if background is not None:

--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -277,7 +277,13 @@ class Plotter:
         mesh.grid["result"] = overall_data
         mesh_to_compute = mesh.grid.extract_surface()
         nan_mask = np.isnan(mesh_to_compute["result"])
+        if len(nan_mask.shape) > 1:
+            if (nan_mask.shape[1] > 1):
+                nan_mask = nan_mask[:,1]
         val_mask = ~np.isnan(mesh_to_compute["result"])
+        if len(val_mask.shape) > 1:
+            if (val_mask.shape[1] > 1):
+                val_mask = val_mask[:,1]
         nan_grid = mesh_to_compute.extract_points(nan_mask, adjacent_cells=False)
         val_grid = mesh_to_compute.extract_points(val_mask, adjacent_cells=False)
         nan_field = mesh_to_compute["result"][nan_mask]


### PR DESCRIPTION
Using the following code, we see that transparency is now working while trying to plot a result not over the whole mesh : 

```
from ansys.dpf import core
core.connect_to_server('10.110.2.65', 50052)
from ansys.dpf.core import examples
```

```
filepath = examples.multishells_rst
ds = core.DataSources(filepath)
model = core.Model(filepath) 
mesh = model.metadata.meshed_region
stress = model.operator("SX") ## ISSUE 2 # replace by S
stress.inputs.requested_location.connect('Nodal')
s = stress.outputs.fields_container()
mesh.plot(s[1], shell_layers = core.shell_layers.top)
```


![image](https://user-images.githubusercontent.com/74727146/142009092-ce7d81cd-6fb8-427b-9f86-93f2c1b5119e.png)


It seems the issue pointed out in #12 is solved. Closing this one.
