### PR TITLE
CI/CD: Run the pydpf-post unit tests

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -280,8 +280,12 @@ jobs:
         if [ -z ${SYSTEM_PULLREQUEST_SOURCEBRANCH} ]; then 
         export var_to_check=${SYSTEM_PULLREQUEST_SOURCEBRANCH}
         export subbranch=${var_to_check}
+        echo "subbranch is now set to $subbranch using pr_branch $SYSTEM_PULLREQUEST_SOURCEBRANCH"
+        echo ----------------------- 
         else 
         export subbranch=${var_to_check#"$prefix"}
+        echo "subbranch is now set to $subbranch"
+        echo ----------------------- 
         fi
         export branch_to_check="origin/"${subbranch}
         git branch -r > branch_output.txt

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -278,13 +278,13 @@ jobs:
         export prefix="refs/heads/"
         export var_to_check=${BUILD_SOURCEBRANCH}
         if [ -z ${SYSTEM_PULLREQUEST_SOURCEBRANCH} ]; then 
+        export subbranch=${var_to_check#"$prefix"}
+        echo "subbranch is now set to $subbranch"
+        echo ----------------------- 
+        else 
         export var_to_check=${SYSTEM_PULLREQUEST_SOURCEBRANCH}
         export subbranch=${var_to_check}
         echo "subbranch is now set to $subbranch using pr_branch $SYSTEM_PULLREQUEST_SOURCEBRANCH"
-        echo ----------------------- 
-        else 
-        export subbranch=${var_to_check#"$prefix"}
-        echo "subbranch is now set to $subbranch"
         echo ----------------------- 
         fi
         export branch_to_check="origin/"${subbranch}

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -101,7 +101,10 @@ jobs:
         dir
         
         set branch_name=$(Build.SourceBranch)
-        set subbranch_cut=%branch_name:refs/heads/=%
+        IF DEFINED SYSTEM_PULLREQUEST_SOURCEBRANCH (SET subbranch_cut=%SYSTEM_PULLREQUEST_SOURCEBRANCH%) ELSE (SET subbranch_cut=%branch_name:refs/heads/=%)
+        echo -----------------------  
+        echo "subbranch_cut is %subbranch_cut%"
+        echo -----------------------  
         set subbranch=origin/%subbranch_cut%
         git branch -r > branch_output.txt
         find /c %subbranch% branch_output.txt >NUL
@@ -273,7 +276,13 @@ jobs:
         ls
       
         export prefix="refs/heads/"
-        export subbranch=${BUILD_SOURCEBRANCH#"$prefix"}
+        export var_to_check=${BUILD_SOURCEBRANCH}
+        if [ -z ${SYSTEM_PULLREQUEST_SOURCEBRANCH} ]; then 
+        export var_to_check=${SYSTEM_PULLREQUEST_SOURCEBRANCH}
+        export subbranch=${var_to_check}
+        else 
+        export subbranch=${var_to_check#"$prefix"}
+        fi
         export branch_to_check="origin/"${subbranch}
         git branch -r > branch_output.txt
         if grep -q $branch_to_check ./branch_output.txt; then 

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -45,47 +45,6 @@ jobs:
     - script: |
         pip install -r requirements_test.txt
       displayName: Install Test Environment
-
-    - script: |
-        set THISDIR=$(System.DefaultWorkingDirectory)
-        cd tests
-        set AWP_ROOT212=%THISDIR%\server\v212
-        pytest -v --junitxml=junit/test-results.xml --cov ansys.dpf.core --cov-report=xml --reruns 3
-        
-      displayName: Test Core API
-      timeoutInMinutes: 10
-
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: 'tests/junit/test-results.xml'
-        testRunTitle: 'windowsTestsCore'
-        publishRunAttachments: true
-      condition: always()
-
-    - script: |
-        set THISDIR=$(System.DefaultWorkingDirectory)
-        cd $(System.DefaultWorkingDirectory)
-        set AWP_ROOT212=%THISDIR%\server\v212
-        pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys\dpf\core
-      condition: always()
-      displayName: Test API Docstrings
-      timeoutInMinutes: 5
-
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: 'junit/test-doctests-results.xml'
-        testRunTitle: 'docTestsTests'
-        publishRunAttachments: true
-      condition: always()
-
-    - script:  |
-        set THISDIR=$(System.DefaultWorkingDirectory)
-        set AWP_ROOT212=%THISDIR%\server\v212
-        python .ci/run_examples.py
-      displayName: 'Run example scripts'
-      timeoutInMinutes: 5
       
     - script: |
         set THISDIR=$(System.DefaultWorkingDirectory)
@@ -135,6 +94,47 @@ jobs:
       condition: always()
 
     - script: |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        cd tests
+        set AWP_ROOT212=%THISDIR%\server\v212
+        pytest -v --junitxml=junit/test-results.xml --cov ansys.dpf.core --cov-report=xml --reruns 3
+        
+      displayName: Test Core API
+      timeoutInMinutes: 10
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'tests/junit/test-results.xml'
+        testRunTitle: 'windowsTestsCore'
+        publishRunAttachments: true
+      condition: always()
+
+    - script: |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        cd $(System.DefaultWorkingDirectory)
+        set AWP_ROOT212=%THISDIR%\server\v212
+        pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys\dpf\core
+      condition: always()
+      displayName: Test API Docstrings
+      timeoutInMinutes: 5
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'junit/test-doctests-results.xml'
+        testRunTitle: 'docTestsTests'
+        publishRunAttachments: true
+      condition: always()
+
+    - script:  |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        set AWP_ROOT212=%THISDIR%\server\v212
+        python .ci/run_examples.py
+      displayName: 'Run example scripts'
+      timeoutInMinutes: 5
+
+    - script: |
         pip install twine
         python setup.py sdist
         twine upload --skip-existing dist/*
@@ -155,6 +155,7 @@ jobs:
       
 
 - job: Linux
+  condition: eq(1, 2)
   variables:
     python.version: '3.7'  # due to VTK 8.1.2 requirement for docbuild
     DISPLAY: ':99.0'
@@ -318,6 +319,7 @@ jobs:
 
 
 - job: DocumentationWindows
+  condition: eq(1, 2)
   variables:
     python.version: '3.8'
     DISPLAY: ':99.0'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -299,7 +299,7 @@ jobs:
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: 'JUnit'
-        testResultsFiles: '$(Build.BinariesDirectory)/pydpf-post/junit/test-results-post.xml' 
+        testResultsFiles: '$(Build.BinariesDirectory)/pydpf-post/tests/junit/test-results-post.xml' 
         testRunTitle: 'linuxTestsPost'
         publishRunAttachments: true
         searchFolder: 'tests/'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -155,7 +155,6 @@ jobs:
       
 
 - job: Linux
-  condition: eq(1, 2)
   variables:
     python.version: '3.7'  # due to VTK 8.1.2 requirement for docbuild
     DISPLAY: ':99.0'
@@ -319,7 +318,6 @@ jobs:
 
 
 - job: DocumentationWindows
-  condition: eq(1, 2)
   variables:
     python.version: '3.8'
     DISPLAY: ':99.0'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -59,7 +59,27 @@ jobs:
       inputs:
         testResultsFormat: 'JUnit'
         testResultsFiles: 'tests/junit/test-results.xml'
-        testRunTitle: 'windowsTests'
+        testRunTitle: 'windowsTestsCore'
+        publishRunAttachments: true
+      condition: always()
+      
+    - script: |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        set AWP_ROOT212=%THISDIR%\server\v212
+        cd $(Build.BinariesDirectory)
+        git clone -n --depth=1 -b master https://github.com/pyansys/pydpf-post
+        cd pydpf-post
+        pip install .
+        cd tests
+        pytest -v --junitxml=junit/test-results-post.xml --cov ansys.dpf.post --cov-report=xml --reruns 3
+        echo %PATH%
+      displayName: Test Post API
+      
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'tests/junit/test-results-post.xml'
+        testRunTitle: 'windowsTestsPost'
         publishRunAttachments: true
       condition: always()
 
@@ -183,7 +203,10 @@ jobs:
       
     - script: |
         pip install -r requirements_test.txt
-        pip install pytest-azurepipelines        
+        pip install pytest-azurepipelines
+      displayName: Install Test Environment
+      
+    - script: |    
         export AWP_ROOT212=${SYSTEM_DEFAULTWORKINGDIRECTORY}/server/v212
         cd tests
         export DPF_IP=$(hostname -i)
@@ -196,7 +219,29 @@ jobs:
       inputs:
         testResultsFormat: 'JUnit'
         testResultsFiles: 'junit/test-results.xml' 
-        testRunTitle: 'linuxTests'
+        testRunTitle: 'linuxTestsCore'
+        publishRunAttachments: true
+        searchFolder: 'tests/'
+      condition: always()
+      
+    - script: |    
+        export AWP_ROOT212=${SYSTEM_DEFAULTWORKINGDIRECTORY}/server/v212
+        export DPF_IP=$(hostname -i)
+        cd ${BUILD_BINARIESDIRECTORY}
+        git clone -n --depth=1 -b master https://github.com/pyansys/pydpf-post
+        cd pydpf-post
+        pip install .
+        cd tests
+        pytest -v --junitxml=junit/test-results-post.xml --cov ansys.dpf.core --cov-report=xml  --reruns 3      
+        export PATH=`pwd`
+        echo ${PATH} 
+      displayName: Test Post API
+      
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'junit/test-results-post.xml' 
+        testRunTitle: 'linuxTestsPost'
         publishRunAttachments: true
         searchFolder: 'tests/'
       condition: always()

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -99,6 +99,27 @@ jobs:
         echo "is in pydpf-post"
         echo "------------------"
         dir
+        
+        set branch_name=$(Build.SourceBranch)
+        set subbranch_cut=%branch_name:refs/heads/=%
+        set subbranch=origin/%subbranch_cut%
+        git branch -r > branch_output.txt
+        find /c %subbranch% branch_output.txt >NUL
+        if %errorlevel% equ 1 goto notfound
+            echo -----------------------
+            echo "subbranch %subbranch% will be fetched"
+            git fetch origin %subbranch%
+            git checkout %subbranch%
+            echo "subbranch is now set to %subbranch%"
+            echo -----------------------            
+        goto done
+        :notfound
+            echo -----------------------
+            echo "master branch is now set"
+            echo -----------------------
+        goto done
+        :done
+        
         pip install . --no-deps
         cd tests
         pytest -v --junitxml=junit/test-results-post.xml --cov ansys.dpf.post --cov-report=xml --reruns 3

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
         echo "is in pydpf-post"
         echo "------------------"
         dir
-        pip install .
+        pip install . --no-deps
         cd tests
         pytest -v --junitxml=junit/test-results-post.xml --cov ansys.dpf.post --cov-report=xml --reruns 3
         echo %PATH%
@@ -268,7 +268,7 @@ jobs:
         echo -----------------------
         fi
         
-        pip install .
+        pip install . --no-deps
         cd tests
         pytest -v --junitxml=junit/test-results-post.xml --cov ansys.dpf.core --cov-report=xml  --reruns 3      
         export PATH=`pwd`

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -62,6 +62,23 @@ jobs:
         testRunTitle: 'windowsTestsCore'
         publishRunAttachments: true
       condition: always()
+
+    - script: |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        cd $(System.DefaultWorkingDirectory)
+        set AWP_ROOT212=%THISDIR%\server\v212
+        pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys\dpf\core
+      condition: always()
+      displayName: Test API Docstrings
+      timeoutInMinutes: 5
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'junit/test-doctests-results.xml'
+        testRunTitle: 'docTestsTests'
+        publishRunAttachments: true
+      condition: always()
       
     - script: |
         set THISDIR=$(System.DefaultWorkingDirectory)
@@ -86,23 +103,6 @@ jobs:
         testResultsFormat: 'JUnit'
         testResultsFiles: 'tests/junit/test-results-post.xml'
         testRunTitle: 'windowsTestsPost'
-        publishRunAttachments: true
-      condition: always()
-
-    - script: |
-        set THISDIR=$(System.DefaultWorkingDirectory)
-        cd $(System.DefaultWorkingDirectory)
-        set AWP_ROOT212=%THISDIR%\server\v212
-        pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys\dpf\core
-      condition: always()
-      displayName: Test API Docstrings
-      timeoutInMinutes: 5
-
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: 'junit/test-doctests-results.xml'
-        testRunTitle: 'docTestsTests'
         publishRunAttachments: true
       condition: always()
 
@@ -229,7 +229,9 @@ jobs:
         publishRunAttachments: true
         searchFolder: 'tests/'
       condition: always()
-      
+     
+    # to run tests on pydpf-post specific branch, the 
+    # branch name must be the same as the pydpf-core one
     - script: |    
         export AWP_ROOT212=${SYSTEM_DEFAULTWORKINGDIRECTORY}/server/v212
         export DPF_IP=$(hostname -i)
@@ -248,6 +250,24 @@ jobs:
         echo "is in pydpf-post"
         echo "------------------"
         ls
+        
+        export prefix="refs/heads/"
+        export subbranch=${BUILD_SOURCEBRANCH#"$prefix"}
+        export branch_to_check="origin/"${subbranch}
+        git branch -r > branch_output.txt
+        if grep -q $branch_to_check ./branch_output.txt; then 
+        echo -----------------------
+        echo "subbranch will be fetched"
+        git fetch origin $subbranch
+        git checkout $subbranch
+        echo "subbranch is now set"
+        echo -----------------------
+        else 
+        echo -----------------------
+        echo "master branch is now set"
+        echo -----------------------
+        fi
+        
         pip install .
         cd tests
         pytest -v --junitxml=junit/test-results-post.xml --cov ansys.dpf.core --cov-report=xml  --reruns 3      

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -67,8 +67,14 @@ jobs:
         set THISDIR=$(System.DefaultWorkingDirectory)
         set AWP_ROOT212=%THISDIR%\server\v212
         cd $(Build.BinariesDirectory)
+        echo "is in $(Build.BinariesDirectory)"
+        echo "------------------"
+        dir
         git clone -n --depth=1 -b master https://github.com/pyansys/pydpf-post
         cd pydpf-post
+        echo "is in pydpf-post"
+        echo "------------------"
+        dir
         pip install .
         cd tests
         pytest -v --junitxml=junit/test-results-post.xml --cov ansys.dpf.post --cov-report=xml --reruns 3
@@ -228,8 +234,20 @@ jobs:
         export AWP_ROOT212=${SYSTEM_DEFAULTWORKINGDIRECTORY}/server/v212
         export DPF_IP=$(hostname -i)
         cd ${BUILD_BINARIESDIRECTORY}
+        echo "path of ${BUILD_BINARIESDIRECTORY}"
+        echo "------------------"
+        pwd -P
+        echo "is in ${BUILD_BINARIESDIRECTORY}"
+        echo "------------------"
+        ls
         git clone -n --depth=1 -b master https://github.com/pyansys/pydpf-post
         cd pydpf-post
+        echo "path of pydpf-post"
+        echo "------------------"
+        pwd -P
+        echo "is in pydpf-post"
+        echo "------------------"
+        ls
         pip install .
         cd tests
         pytest -v --junitxml=junit/test-results-post.xml --cov ansys.dpf.core --cov-report=xml  --reruns 3      

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
         echo "is in $(Build.BinariesDirectory)"
         echo "------------------"
         dir
-        git clone -n --depth=1 -b master https://github.com/pyansys/pydpf-post
+        git clone https://github.com/pyansys/pydpf-post
         cd pydpf-post
         echo "is in pydpf-post"
         echo "------------------"
@@ -240,7 +240,7 @@ jobs:
         echo "is in ${BUILD_BINARIESDIRECTORY}"
         echo "------------------"
         ls
-        git clone -n --depth=1 -b master https://github.com/pyansys/pydpf-post
+        git clone https://github.com/pyansys/pydpf-post
         cd pydpf-post
         echo "path of pydpf-post"
         echo "------------------"

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -45,6 +45,47 @@ jobs:
     - script: |
         pip install -r requirements_test.txt
       displayName: Install Test Environment
+
+    - script: |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        cd tests
+        set AWP_ROOT212=%THISDIR%\server\v212
+        pytest -v --junitxml=junit/test-results.xml --cov ansys.dpf.core --cov-report=xml --reruns 3
+        
+      displayName: Test Core API
+      timeoutInMinutes: 10
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'tests/junit/test-results.xml'
+        testRunTitle: 'windowsTestsCore'
+        publishRunAttachments: true
+      condition: always()
+
+    - script: |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        cd $(System.DefaultWorkingDirectory)
+        set AWP_ROOT212=%THISDIR%\server\v212
+        pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys\dpf\core
+      condition: always()
+      displayName: Test API Docstrings
+      timeoutInMinutes: 5
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'junit/test-doctests-results.xml'
+        testRunTitle: 'docTestsTests'
+        publishRunAttachments: true
+      condition: always()
+
+    - script:  |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        set AWP_ROOT212=%THISDIR%\server\v212
+        python .ci/run_examples.py
+      displayName: 'Run example scripts'
+      timeoutInMinutes: 5
       
     - script: |
         set THISDIR=$(System.DefaultWorkingDirectory)
@@ -92,47 +133,6 @@ jobs:
         testRunTitle: 'windowsTestsPost'
         publishRunAttachments: true
       condition: always()
-
-    - script: |
-        set THISDIR=$(System.DefaultWorkingDirectory)
-        cd tests
-        set AWP_ROOT212=%THISDIR%\server\v212
-        pytest -v --junitxml=junit/test-results.xml --cov ansys.dpf.core --cov-report=xml --reruns 3
-        
-      displayName: Test Core API
-      timeoutInMinutes: 10
-
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: 'tests/junit/test-results.xml'
-        testRunTitle: 'windowsTestsCore'
-        publishRunAttachments: true
-      condition: always()
-
-    - script: |
-        set THISDIR=$(System.DefaultWorkingDirectory)
-        cd $(System.DefaultWorkingDirectory)
-        set AWP_ROOT212=%THISDIR%\server\v212
-        pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys\dpf\core
-      condition: always()
-      displayName: Test API Docstrings
-      timeoutInMinutes: 5
-
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: 'junit/test-doctests-results.xml'
-        testRunTitle: 'docTestsTests'
-        publishRunAttachments: true
-      condition: always()
-
-    - script:  |
-        set THISDIR=$(System.DefaultWorkingDirectory)
-        set AWP_ROOT212=%THISDIR%\server\v212
-        python .ci/run_examples.py
-      displayName: 'Run example scripts'
-      timeoutInMinutes: 5
 
     - script: |
         pip install twine

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: 'JUnit'
-        testResultsFiles: 'tests/junit/test-results-post.xml'
+        testResultsFiles: '$(Build.BinariesDirectory)/pydpf-post/tests/junit/test-results-post.xml'
         testRunTitle: 'windowsTestsPost'
         publishRunAttachments: true
       condition: always()
@@ -299,7 +299,7 @@ jobs:
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: 'JUnit'
-        testResultsFiles: 'junit/test-results-post.xml' 
+        testResultsFiles: '$(Build.BinariesDirectory)/pydpf-post/junit/test-results-post.xml' 
         testRunTitle: 'linuxTestsPost'
         publishRunAttachments: true
         searchFolder: 'tests/'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -67,8 +67,8 @@ jobs:
         if %errorlevel% equ 1 goto notfound
             echo -----------------------
             echo "subbranch %subbranch% will be fetched"
-            git fetch origin %subbranch%
-            git checkout %subbranch%
+            git fetch origin %subbranch_cut%
+            git checkout %subbranch_cut%
             echo "subbranch is now set to %subbranch%"
             echo -----------------------            
         goto done

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -107,7 +107,7 @@ jobs:
         echo -----------------------  
         set subbranch=origin/%subbranch_cut%
         git branch -r > branch_output.txt
-        find /c %subbranch% branch_output.txt >NUL
+        find /c "%subbranch%" branch_output.txt >NUL
         if %errorlevel% equ 1 goto notfound
             echo -----------------------
             echo "subbranch %subbranch% will be fetched"

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -79,6 +79,13 @@ jobs:
         testRunTitle: 'docTestsTests'
         publishRunAttachments: true
       condition: always()
+
+    - script:  |
+        set THISDIR=$(System.DefaultWorkingDirectory)
+        set AWP_ROOT212=%THISDIR%\server\v212
+        python .ci/run_examples.py
+      displayName: 'Run example scripts'
+      timeoutInMinutes: 5
       
     - script: |
         set THISDIR=$(System.DefaultWorkingDirectory)
@@ -105,13 +112,6 @@ jobs:
         testRunTitle: 'windowsTestsPost'
         publishRunAttachments: true
       condition: always()
-
-    - script:  |
-        set THISDIR=$(System.DefaultWorkingDirectory)
-        set AWP_ROOT212=%THISDIR%\server\v212
-        python .ci/run_examples.py
-      displayName: 'Run example scripts'
-      timeoutInMinutes: 5
 
     - script: |
         pip install twine
@@ -250,17 +250,17 @@ jobs:
         echo "is in pydpf-post"
         echo "------------------"
         ls
-        
+      
         export prefix="refs/heads/"
         export subbranch=${BUILD_SOURCEBRANCH#"$prefix"}
         export branch_to_check="origin/"${subbranch}
         git branch -r > branch_output.txt
         if grep -q $branch_to_check ./branch_output.txt; then 
         echo -----------------------
-        echo "subbranch will be fetched"
+        echo "subbranch $subbranch will be fetched"
         git fetch origin $subbranch
         git checkout $subbranch
-        echo "subbranch is now set"
+        echo "subbranch is now set to $subbranch"
         echo -----------------------
         else 
         echo -----------------------

--- a/ansys/dpf/core/_version.py
+++ b/ansys/dpf/core/_version.py
@@ -1,6 +1,6 @@
 """Version for ansys-dpf-core"""
 # major, minor, patch
-version_info = 0, 3, "dev0"
+version_info = 0, 3, "dev3"
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
In CI/CD process, add "Test Post API" for both Linux and Windows jobs. 
The post repository is cloned and installed to proceed. If you want to run tests on a specific pydpf-post banch (in case of some breaking changes would be added in pydpf-core and that we want to add fixes on pydpf-post side), it must have the same name that this repository (pydpf-core) branch the CI /CD is running on. 

**Next steps**
Check that both PR and branch CI/CD works (check the branch that is cloned into Test Post API task). 
Fix conflicts once #122 is merged. 
Re-run the CI/CD once #53 is merged and that cicd/run_post_tests branch have been suppressed from pydpf-post repository (it will allow to check the CI/CD mechanism for the master branch). 
