### PR TITLE
custom title for mesh.plot(field)

### DIFF
--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -271,6 +271,9 @@ class Plotter:
         kwargs.setdefault("show_edges", True)
         kwargs.setdefault("nan_color", "grey")
         kwargs.setdefault("stitle", name)
+        text = kwargs.pop('text', None)
+        if text is not None:
+            plotter.add_text(text, position='lower_edge')
         plotter.add_mesh(mesh.grid, scalars=overall_data, **kwargs)
 
         if background is not None:

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -207,6 +207,23 @@ def test_plot_fields_on_mesh_scoping(multishells):
     s = stress.outputs.fields_container()
     mesh.plot(s[0])
 
+    
+@pytest.mark.skipif(not HAS_PYVISTA, reason="Please install pyvista")
+def test_plot_fields_on_mesh_scoping_title(multishells):
+    model = core.Model(multishells)
+    mesh = model.metadata.meshed_region
+    stress = model.results.stress()
+    stress.inputs.requested_location.connect("Nodal")
+    scoping = core.Scoping()
+    scoping.location = "Nodal"
+    l = list(range(0, 400))
+    l += list(range(1500, 2000))
+    l += list(range(2200, 2600))
+    scoping.ids = l
+    stress.inputs.mesh_scoping.connect(scoping)
+    s = stress.outputs.fields_container()
+    mesh.plot(s[0], text="test")
+
 
 @pytest.mark.skipif(not HAS_PYVISTA, reason="Please install pyvista")
 def test_throw_on_several_time_steps(plate_msup):

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -207,7 +207,7 @@ def test_plot_fields_on_mesh_scoping(multishells):
     s = stress.outputs.fields_container()
     mesh.plot(s[0])
 
-    
+
 @pytest.mark.skipif(not HAS_PYVISTA, reason="Please install pyvista")
 def test_plot_fields_on_mesh_scoping_title(multishells):
     model = core.Model(multishells)


### PR DESCRIPTION
Fixes #88 
Quick fix, adding recognition of "text" argument for simple custom title definition by adding text on the lower_edge using pyvista.Plotter.add_text
(NB: This is sort of a test)