### PR TITLE
static CommonResults should be returned when the available results co…

### DIFF
--- a/ansys/dpf/core/model.py
+++ b/ansys/dpf/core/model.py
@@ -155,6 +155,8 @@ class Model:
             if misc.DYNAMIC_RESULTS:
                 try:
                     self._results = Results(self)
+                    if len(self._results) == 0:
+                        self._results = CommonResults(self)
                 except Exception as e:
                     self._results = CommonResults(self)
                     LOG.debug(str(e))


### PR DESCRIPTION
…uldn't be accessed