### PR TITLE
Doc: fix Contributing - cloning commands snippet

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -20,11 +20,7 @@ You can clone the source repository from `DPF-Core
 GitHub <https://https://github.com/pyansys/DPF-Core>`_
 and install the latest version in development mode by running:
 
-.. code::
-
-    git clone https://github.com/pyansys/DPF-Core DPF-Core
-    cd DPF-Core
-    pip install -e .
+.. include:: pydpf-core_clone_install.rst
 
 
 Questions

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -28,9 +28,5 @@ If you want to edit and potentially contribute to the DPF-Core
 module, clone the repository and install it using pip with the ``-e``
 development flag:
 
-.. code::
-
-    git clone https://github.com/pyansys/pydpf-core
-    cd pydpf-core
-    pip install -e .
+.. include:: ../pydpf-core_clone_install.rst
 

--- a/docs/source/pydpf-core_clone_install.rst
+++ b/docs/source/pydpf-core_clone_install.rst
@@ -1,0 +1,5 @@
+.. code::
+
+    git clone https://github.com/pyansys/pydpf-core
+    cd pydpf-core
+    pip install -e .


### PR DESCRIPTION
install.rst and contributing.rst now point to a common code snippet in pydpf-core_clone_install.rst for cloning and installation commands (contributing page was outdated)