### PR TITLE
Improve ImportWarning in check_ansys_grpc_dpf_version

### DIFF
--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -692,7 +692,7 @@ def check_ansys_grpc_dpf_version(server, timeout=10.):
                             f"({server_version} "
                             f"from Ansys {server_to_ansys_version.get(server_version, 'Unknown')})"
                             f" and the ansys-grpc-dpf version installed ({grpc_module_version})."
-                            f" Please consider using the newest DPF server available in the "
+                            f" Please consider using the lastest DPF server available in the "
                             f"2022R1 Ansys unified install.\n"
                             f"To follow the compatibility guidelines given in "
                             f"{compatibility_link} while still using DPF server {server_version}, "

--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -692,7 +692,7 @@ def check_ansys_grpc_dpf_version(server, timeout=10.):
                             f"({server_version} "
                             f"from Ansys {server_to_ansys_version.get(server_version, 'Unknown')})"
                             f" and the ansys-grpc-dpf version installed ({grpc_module_version})."
-                            f" Please consider using the lastest DPF server available in the "
+                            f" Please consider using the latest DPF server available in the "
                             f"2022R1 Ansys unified install.\n"
                             f"To follow the compatibility guidelines given in "
                             f"{compatibility_link} while still using DPF server {server_version}, "

--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -686,7 +686,8 @@ def check_ansys_grpc_dpf_version(server, timeout=10.):
     server_version = server.version
     right_grpc_module_version = server_to_ansys_grpc_dpf_version.get(server_version, None)
     if right_grpc_module_version and right_grpc_module_version != grpc_module_version:
-        compatibility_link = r"https://dpfdocs.pyansys.com/getting_started/index.html#client-server-compatibility"
+        compatibility_link = (f"https://dpfdocs.pyansys.com/getting_started/"
+                              f"index.html#client-server-compatibility")
         raise ImportWarning(f"An incompatibility has been detected between the server version"
                             f"({server_version} " 
                             f"from Ansys {server_to_ansys_version.get(server_version, 'Unknown')})"

--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -688,14 +688,14 @@ def check_ansys_grpc_dpf_version(server, timeout=10.):
     if right_grpc_module_version and right_grpc_module_version != grpc_module_version:
         compatibility_link = (f"https://dpfdocs.pyansys.com/getting_started/"
                               f"index.html#client-server-compatibility")
-        raise ImportWarning(f"An incompatibility has been detected between the server version "
+        raise ImportWarning(f"An incompatibility has been detected between the DPF server version "
                             f"({server_version} "
                             f"from Ansys {server_to_ansys_version.get(server_version, 'Unknown')})"
                             f" and the ansys-grpc-dpf version installed ({grpc_module_version})."
-                            f" Please consider using the 2022R1 Ansys unified install "
-                            f"which is now available. "
+                            f" Please consider using the newest DPF server available in the "
+                            f"2022R1 Ansys unified install.\n"
                             f"To follow the compatibility guidelines given in "
-                            f"{compatibility_link} and still use DPF server {server_version}, "
+                            f"{compatibility_link} while still using DPF server {server_version}, "
                             f"please install version {right_grpc_module_version} of ansys-grpc-dpf"
                             f" with the command: \n"
                             f"     pip install ansys-grpc-dpf=={right_grpc_module_version}"

--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -689,7 +689,7 @@ def check_ansys_grpc_dpf_version(server, timeout=10.):
         compatibility_link = (f"https://dpfdocs.pyansys.com/getting_started/"
                               f"index.html#client-server-compatibility")
         raise ImportWarning(f"An incompatibility has been detected between the server version"
-                            f"({server_version} " 
+                            f"({server_version} "
                             f"from Ansys {server_to_ansys_version.get(server_version, 'Unknown')})"
                             f" and the ansys-grpc-dpf version installed ({grpc_module_version})"
                             f"To follow the compatibility guidelines given in "

--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -660,7 +660,8 @@ def launch_dpf(ansys_path, ip=LOCALHOST, port=DPF_DEFAULT_PORT, timeout=10., doc
             pass
         errstr = "\n".join(errors)
         if "Only one usage of each socket address" in errstr:
-            raise errors.InvalidPortError(f"Port {port} in use")
+            from ansys.dpf.core.errors import InvalidPortError
+            raise InvalidPortError(f"Port {port} in use")
         raise RuntimeError(errstr)
 
     if len(docker_id) > 0:
@@ -685,11 +686,22 @@ def check_ansys_grpc_dpf_version(server, timeout=10.):
     server_version = server.version
     right_grpc_module_version = server_to_ansys_grpc_dpf_version.get(server_version, None)
     if right_grpc_module_version and right_grpc_module_version != grpc_module_version:
-        raise ImportWarning(f"2022R1 Ansys unified install is available. "
-                            f"To use DPF server from Ansys "
-                            f"{server_to_ansys_version.get(server_version, 'Unknown')}"
-                            f" (dpf.SERVER.version=='{server_version}'), "
-                            f"install version {right_grpc_module_version} of ansys-grpc-dpf"
+        compatibility_link = r"https://dpfdocs.pyansys.com/getting_started/index.html#client-server-compatibility"
+        raise ImportWarning(f"An incompatibility has been detected between the server version"
+                            f"({server_version} " 
+                            f"from Ansys {server_to_ansys_version.get(server_version, 'Unknown')})"
+                            f" and the ansys-grpc-dpf version installed ({grpc_module_version})"
+                            f"To follow the compatibility guidelines given in "
+                            f"{compatibility_link} and use DPF server {server_version}, "
+                            f"please install version {right_grpc_module_version} of ansys-grpc-dpf"
                             f" with the command: \n"
                             f"     pip install ansys-grpc-dpf=={right_grpc_module_version}"
                             )
+        # raise ImportWarning(f"2022R1 Ansys unified install is available. "
+        #                     f"To use DPF server from Ansys "
+        #                     f"{server_to_ansys_version.get(server_version, 'Unknown')}"
+        #                     f" (dpf.SERVER.version=='{server_version}'), "
+        #                     f"install version {right_grpc_module_version} of ansys-grpc-dpf"
+        #                     f" with the command: \n"
+        #                     f"     pip install ansys-grpc-dpf=={right_grpc_module_version}"
+        #                     )

--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -688,12 +688,14 @@ def check_ansys_grpc_dpf_version(server, timeout=10.):
     if right_grpc_module_version and right_grpc_module_version != grpc_module_version:
         compatibility_link = (f"https://dpfdocs.pyansys.com/getting_started/"
                               f"index.html#client-server-compatibility")
-        raise ImportWarning(f"An incompatibility has been detected between the server version"
+        raise ImportWarning(f"An incompatibility has been detected between the server version "
                             f"({server_version} "
                             f"from Ansys {server_to_ansys_version.get(server_version, 'Unknown')})"
-                            f" and the ansys-grpc-dpf version installed ({grpc_module_version})"
+                            f" and the ansys-grpc-dpf version installed ({grpc_module_version})."
+                            f" Please consider using the 2022R1 Ansys unified install "
+                            f"which is now available. "
                             f"To follow the compatibility guidelines given in "
-                            f"{compatibility_link} and use DPF server {server_version}, "
+                            f"{compatibility_link} and still use DPF server {server_version}, "
                             f"please install version {right_grpc_module_version} of ansys-grpc-dpf"
                             f" with the command: \n"
                             f"     pip install ansys-grpc-dpf=={right_grpc_module_version}"


### PR DESCRIPTION
The ImportWarning when using an incompatible version of ansys.grpc.dpf is now clearer and give a link to the Compatibility section in the docs.
The previous message stated "2022R1 Ansys unified install is available" instead of "unavailable".
Also changed the raise of InvalidPortError as the use of namespace errors conflicted with the use of variable errors in the preceding lines of code.