### PR TITLE
Fixed index issue when getting scalar field value for a node.

### DIFF
--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -109,7 +109,7 @@ class _InternalPlotter:
                                                                    [labels[index]],
                                                                    **kwargs))
             else:
-                scalar_at_index = meshed_region.grid.active_scalars[index]
+                scalar_at_index = meshed_region.grid.active_scalars[node_indexes[index]]
                 scalar_at_grid_point = f"{scalar_at_index:.2f}"
                 label_actors.append(self._plotter.add_point_labels(grid_point,
                                                                    [scalar_at_grid_point],

--- a/examples/05-plotting/03-labels.py
+++ b/examples/05-plotting/03-labels.py
@@ -38,10 +38,22 @@ print(model)
 #
 stress_tensor = model.results.stress()
 time_scope = dpf.Scoping()
-time_scope.ids = [1, 2]
+time_scope.ids = [20]  # [1, 2]
 stress_tensor.inputs.time_scoping.connect(time_scope)
 stress_tensor.inputs.requested_location.connect("Nodal")
+# field = stress_tensor.outputs.fields_container.get_data()[0]
 
+norm_op = dpf.Operator("norm_fc")
+norm_op.inputs.connect(stress_tensor.outputs)
+field_norm_stress = norm_op.outputs.fields_container()[0]
+print(field_norm_stress)
+
+norm_op2 = dpf.Operator("norm_fc")
+disp = model.results.displacement()
+disp.inputs.time_scoping.connect(time_scope)
+norm_op2.inputs.connect(disp.outputs)
+field_norm_disp = norm_op2.outputs.fields_container()[0]
+print(field_norm_disp)
 ###############################################################################
 #  Get the meshed region
 #
@@ -52,13 +64,14 @@ mesh_set = model.metadata.meshed_region
 #
 plot = DpfPlotter()
 plot.add_field(
-    stress_tensor.outputs.fields_container.get_data()[1],
+    field_norm_stress,
     meshed_region=mesh_set,
     show_max=True,
     show_min=True,
     label_text_size=15,
     label_point_size=5,
 )
+
 
 # Add custom labels to specific nodes with specific label properties.
 # If label for a node is missing, by default nodal value is shown.
@@ -79,18 +92,18 @@ plot.add_node_labels(
     point_size=20,
 )
 
-my_nodes_2 = [mesh_set.nodes[20], mesh_set.nodes[30]]
-my_labels_2 = ["MyNode3"]
+my_nodes_2 = [mesh_set.nodes[18], mesh_set.nodes[30]]
+my_labels_2 = []  # ["MyNode3"]
 plot.add_node_labels(
     my_nodes_2,
     mesh_set,
     my_labels_2,
-    font_size=30,
+    font_size=15,
     text_color="black",
     font_family="arial",
     shadow=False,
     point_color="white",
-    point_size=30,
+    point_size=15,
 )
 
 # Show figure

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -478,10 +478,12 @@ def test_plot_node_labels(multishells):
     pl = DpfPlotter()
     pl.add_field(field_m, mesh_m)
     my_nodes_1 = [mesh_m.nodes[0], mesh_m.nodes[10]]
-    my_labels_1 = ["MyNode1", "MyNode2"]
+    my_labels_1 = ["MyNode1"]
     pl.add_node_labels(my_nodes_1, mesh_m, my_labels_1,
                        italic=True, bold=True,
                        font_size=26, text_color="white",
                        font_family="courier", shadow=True,
                        point_color="grey", point_size=20)
+    a = pl.labels
+    assert pl.labels[1]
     pl.show_figure()

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -484,6 +484,6 @@ def test_plot_node_labels(multishells):
                        font_size=26, text_color="white",
                        font_family="courier", shadow=True,
                        point_color="grey", point_size=20)
-    a = pl.labels
-    assert pl.labels[1]
+    a = pl.labels[0]
+    assert len(a) == 2
     pl.show_figure()


### PR DESCRIPTION
Issue #219, The code used the index from enumerating the nodes instead of using the index_to_id function when retrieving the scalar value associated with a node in Plotter.add_label(). 