### PR TITLE
Feature: connect_to_server() from a channel

### DIFF
--- a/ansys/dpf/core/server.py
+++ b/ansys/dpf/core/server.py
@@ -366,7 +366,7 @@ class DpfServer:
             if ip is not None or port is not None:
                 raise ValueError("Cannot select the ip and port when providing a channel")
 
-        if channel is None:
+        else:
             ip = ip or LOCALHOST
             port = port or DPF_DEFAULT_PORT
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,6 +55,7 @@ extensions = [
 # Intersphinx mapping
 intersphinx_mapping = {
     "pyvista": ("https://docs.pyvista.org/", None),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
 }
 
 autosummary_generate = True


### PR DESCRIPTION
Fixes #200 

Add the ability for a user to connect to a running DPF server by providing a channel. This enables advanced scenarios such as DPF running behind a gateway, and a channel with interceptors injecting metadata or credentials. This also allows to address DPF by a DNS name instead of an IP.

This will also be the basis for using DPF with PyPIM (in a further PR)