### PR TITLE
Removing link to XML doc

### DIFF
--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -24,5 +24,4 @@ Additionally, :ref:`user_guide_plotting` describes how to plot results via PyVis
    operators
    fields_container
    plotting
-   xmlfiles
    troubleshooting


### PR DESCRIPTION
This feature will only be available starting ANSYS2022R2, so hiding it for now.