### PR TITLE
Improve Compatibility documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,79 @@
+name: 🐞 Bug, problem, error
+description: Fill a bug report here
+title: "Bug located in ..."
+labels: ["bug"]
+assignees: [""]
+
+body:
+
+  - type: markdown
+    attributes:
+      value: '# 🐞 **Problem**'
+
+  - type: checkboxes
+    id: new-bug
+    attributes:
+      label: Before submitting the issue
+      description: Please, make sure the following conditions are met
+      options:
+      - label: I have checked for [Compatibility](https://dpfdocs.pyansys.com/getting_started/index.html#compatibility) issues
+        required: true
+      - label: I have searched among the existing issues
+        required: true
+      - label: I am using a Python virtual environment
+        required: true
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Description of the bug
+      placeholder: Describe what bug you encountered and what should have happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      placeholder: Please write the steps in a list form
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: '# 🖥️ **System Information**'
+
+  - type: dropdown
+    id: os-name
+    attributes:
+      label: Which Operating System are you using?
+      multiple: false
+      options:
+       - 'Windows'
+       - 'MacOS'
+       - 'Linux'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Which Python version are you using?
+      description: Run `python --version` to verify your Python version
+      multiple: false
+      options:
+       - '3.7'
+       - '3.8'
+       - '3.9'
+       - '3.10'
+    validations:
+      required: true
+
+  - type: textarea
+    id: installed-packages
+    attributes:
+      label: Installed packages
+      description: Run `python -m pip freeze` to list installed packages
+      placeholder: Paste the output of `python -m pip freeze` here
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -38,10 +38,20 @@ detailed examples.
 
 ## Installation
 
-Install this repository with:
+DPF requires an Ansys installation and must be compatible with it.
+Compatibility between PyDPF-Core and Ansys is documented 
+[here](https://dpfdocs.pyansys.com/getting_started/index.html#compatibility).
+
+Starting with Ansys 2021R2, install this package with:
 
 ```
 pip install ansys-dpf-core 
+```
+
+For use with Ansys 2021R1, install this package with:
+
+```
+pip install ansys-dpf-core==0.2.1
 ```
 
 You can also clone and install this repository with:

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -4,6 +4,46 @@
 Getting Started
 ===============
 
+Compatibility
+~~~~~~~~~~~~~
+DPF supports Windows 10 and CentOS 7 and later.  For
+more information, see `Ansys Platform Support <https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
+
+Other platforms may be supported by using DPF within a
+containerization ecosystem such as Docker or Kubernetes.
+For more information, see :ref:`docker`.
+
+***************************
+Client Server Compatibility
+***************************
+
+The `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ module should be synchronized
+with the server version as shown here:
+
+.. list-table:: Client-Server Compatibility
+   :widths: 35 35 35
+   :header-rows: 1
+
+   * - Ans.Dpf.Grpc.exe server version
+     - ansys.grpc.dpf python module version
+     - ansys.dpf.core python module version
+   * - 3.0 (Ansys 2022R1)
+     - 0.4.0
+     - >=0.4.0
+   * - 2.0 (Ansys 2021R2)
+     - 0.3.0
+     - >=0.3.0
+   * - 1.0 (Ansys 2021R1)
+     - 0.2.2
+     - 0.2.*
+
+
+Future development will try to ensure backward compatibility from the client to the server.
+
+
+To start a server with Ans.Dpf.Grpc.bat or Ans.Dpf.Grpc.sh (used in the `start_local_server`  function),
+please make sure that the environment variable `AWP_ROOT{VER}` with (VER=212, 221, ...) is set.
+
 Architecture
 ~~~~~~~~~~~~~
 
@@ -96,43 +136,3 @@ Optional package dependencies can be installed for specific usage:
 - `Matplotlib <https://pypi.org/project/matplotlib/>`_ for chart plotting
 - `PyVista <https://pypi.org/project/pyvista/>`_ for 3D plotting
 - `Scooby <https://pypi.org/project/scooby/>`_ for dependency reports
-
-Compatibility
-~~~~~~~~~~~~~
-DPF supports Windows 10 and CentOS 7 and later.  For
-more information, see `Ansys Platform Support <https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
-
-Other platforms may be supported by using DPF within a
-containerization ecosystem such as Docker or Kubernetes. 
-For more information, see :ref:`docker`.
-
-***************************
-Client Server Compatibility
-***************************
-
-The `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ module should be synchronized 
-with the server version as shown here:
-
-.. list-table:: Client-Server Compatibility
-   :widths: 35 35 35
-   :header-rows: 1
-
-   * - Ans.Dpf.Grpc.exe server version
-     - ansys.grpc.dpf python module version
-     - ansys.dpf.core python module version
-   * - 3.0 (Ansys 2022R1)
-     - 0.4.0
-     - >=0.4.0
-   * - 2.0 (Ansys 2021R2)
-     - 0.3.0
-     - >=0.3.0
-   * - 1.0 (Ansys 2021R1)
-     - 0.2.2
-     - 0.2.*
-
-
-Future development will try to ensure backward compatibility from the client to the server.
-
-
-To start a server with Ans.Dpf.Grpc.bat or Ans.Dpf.Grpc.sh (used in the `start_local_server`  function),
-please make sure that the environment variable `AWP_ROOT{VER}` with (VER=212, 221, ...) is set.

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -6,7 +6,7 @@ Getting Started
 
 Compatibility
 ~~~~~~~~~~~~~
-DPF supports Windows 10 and CentOS 7 and later.  For
+DPF supports Windows 10 and CentOS 7 and later. For
 more information, see `Ansys Platform Support <https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
 
 Other platforms may be supported by using DPF within a

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -17,8 +17,15 @@ For more information, see :ref:`docker`.
 Client Server Compatibility
 ***************************
 
-The `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ module should be synchronized
-with the server version as shown here:
+The DPF server version depends on the Ansys installation version.
+The PyDPF-Core client used must be compatible with it according to the table below.
+Notice that starting with Ansys 2021 R2 one can use any PyDPF-Core >= 3.0.
+Only Ansys 2021 R1 requires a specific version of PyDPF-Core (0.2.*).
+
+Future development will always try to ensure backward compatibility from the client to the server.
+
+The `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ module should also be synchronized
+with the server version.
 
 .. list-table:: Client-Server Compatibility
    :widths: 35 35 35
@@ -36,10 +43,6 @@ with the server version as shown here:
    * - 1.0 (Ansys 2021R1)
      - 0.2.2
      - 0.2.*
-
-
-Future development will try to ensure backward compatibility from the client to the server.
-
 
 To start a server with Ans.Dpf.Grpc.bat or Ans.Dpf.Grpc.sh (used in the `start_local_server`  function),
 please make sure that the environment variable `AWP_ROOT{VER}` with (VER=212, 221, ...) is set.

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -9,10 +9,6 @@ Compatibility
 DPF supports Windows 10 and CentOS 7 and later. For
 more information, see `Ansys Platform Support <https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
 
-Other platforms may be supported by using DPF within a
-containerization ecosystem such as Docker or Kubernetes.
-For more information, see :ref:`docker`.
-
 ***************************
 Client Server Compatibility
 ***************************

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -3,19 +3,24 @@
 *********************
 Installation with PIP
 *********************
-Once Ansys 2021 R1 or later is installed, you can install the 
-DPF-Core module with:
+Once Ansys 2021 R2 or later is installed, you can install PyDPF-Core with:
 
 .. code::
 
    pip install ansys-dpf-core
 
 
-This installs the latest version of DPF-Core and all necessary 
+This installs the latest version of PyDPF-Core and all necessary
 dependencies.
 
+To use PyDPF-Core with Ansys 2021 R1, you must install PyDPF-Core with:
+
+.. code::
+
+   pip install ansys-dpf-core<0.3.0
+
 If you are unable to install this module on the host machine due to
-network isolation, download the latest release wheel at `DPF-Core
+network isolation, download the latest or a specific release wheel at `DPF-Core
 GitHub <https://https://github.com/pyansys/DPF-Core>`_ or from PyPi at
 `DPF-Core PyPi <https://pypi.org/project/ansys-dpf-core/>`_
 


### PR DESCRIPTION
- [x] The compatibility table should be at the start of the "Getting Started" page
- [x] It mentions having to synchronize the ansys.grpc.dpf module but not explicitly the server and python client compatibility
- [x] The "Architecture" section mentions Ansys 2021R2 as required while the "Installation with PIP" section mentions "Ansys 2021 R1 or later" and gives only the command pip install ansys-dpf-core which is wrong is using Ansys 2021R1 (should be pip install ansys-dpf-core<0.3.0)
- [x] We might actually want to mention compatibility in the ReadMe, along with specifying that the installation command is for Ansys 2021 R2 onward.
- [x] We can also customize the Issue template to add a tick box with "I made sure I am following the Compatibility guidelines", with an hyperlink to the doc.
- [ ] The Ansys 2021R1 row of the table should be visually separated in some way (thicker boundaries?) --> Could not find how to do this
