### PR TITLE
Fixes the use of notebook argument for plot commands 

### DIFF
--- a/ansys/dpf/core/field.py
+++ b/ansys/dpf/core/field.py
@@ -237,7 +237,7 @@ class Field(_FieldBase):
         op.inputs.connect(self)
         return op.outputs.field()
 
-    def plot(self, notebook=None, shell_layers=None, **kwargs):
+    def plot(self, shell_layers=None, **kwargs):
         """Plot the field or fields container on the mesh support if it exists.
 
         Warning
@@ -259,10 +259,6 @@ class Field(_FieldBase):
 
         Parameters
         ----------
-        notebook : bool, optional
-            Whether the plotting is in the notebook as
-            a static image or is a dynamic plot outside of the
-            notebook. The default is ``None``.
         shell_layers : shell_layers, optional
             Enum used to set the shell layers if the model to plot
             contains shell elements. The default is ``None``.
@@ -271,7 +267,7 @@ class Field(_FieldBase):
             arguments, see ``help(pyvista.plot)``.
         """
         pl = Plotter(self.meshed_region, **kwargs)
-        return pl.plot_contour(self, notebook, shell_layers, **kwargs)
+        return pl.plot_contour(self, shell_layers, **kwargs)
 
     def resize(self, nentities, datasize):
         """Allocate memory.

--- a/ansys/dpf/core/meshed_region.py
+++ b/ansys/dpf/core/meshed_region.py
@@ -368,10 +368,7 @@ class MeshedRegion:
     def plot(
             self,
             field_or_fields_container=None,
-            notebook=None,
             shell_layers=None,
-            off_screen=None,
-            show_axes=True,
             **kwargs
     ):
         """Plot the field or fields container on the mesh.
@@ -380,16 +377,8 @@ class MeshedRegion:
         ----------
         field_or_fields_container : dpf.core.Field or dpf.core.FieldsContainer
             Field or fields container to plot. The default is ``None``.
-        notebook : bool, optional
-            Whether the plotting in the notebook is 2D or 3D. The default is
-            ``None``, in which case the plotting is 2D.
         shell_layers : core.shell_layers, optional
             Enum used to set the shell layers if the model to plot contains shell elements.
-        off_screen : bool, optional
-            Whether to render the plot off screen, which is useful for automated screenshots.
-            The default is "None", in which case the plot renders off screen.
-        show_axes : bool, optional
-            Whether to show a VTK axes widget. The default is ``True``.
         **kwargs : optional
             Additional keyword arguments for the plotter. For additional keyword
             arguments, see ``help(pyvista.plot)``.
@@ -408,15 +397,11 @@ class MeshedRegion:
         """
         if field_or_fields_container is not None:
             pl = Plotter(self, **kwargs)
-            return pl.plot_contour(field_or_fields_container, notebook,
-                                   shell_layers, off_screen, show_axes, **kwargs)
+            return pl.plot_contour(field_or_fields_container, shell_layers, **kwargs)
 
         # otherwise, simply plot the mesh
-        kwargs["off_screen"] = off_screen
-        kwargs["notebook"] = notebook
         pl = DpfPlotter(**kwargs)
         pl.add_mesh(self, **kwargs)
-        kwargs["show_axes"] = show_axes
         return pl.show_figure(**kwargs)
 
     def deep_copy(self, server=None):

--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -712,31 +712,32 @@ class Plotter:
             overall_data[ind] = field.data[mask]
 
         # create the plotter and add the meshes
-        background = kwargs.pop("background", None)
-        cpos = kwargs.pop("cpos", None)
-        return_cpos = kwargs.pop("return_cpos", None)
 
         # add meshes
         kwargs.setdefault("show_edges", True)
         kwargs.setdefault("nan_color", "grey")
         kwargs.setdefault("stitle", name)
+
         text = kwargs.pop('text', None)
         if text is not None:
             self._internal_plotter._plotter.add_text(text, position='lower_edge')
-        kwargs.pop("title", None)
+
         kwargs_in = _sort_supported_kwargs(
             bound_method=self._internal_plotter._plotter.add_mesh,
             **kwargs
             )
         self._internal_plotter._plotter.add_mesh(mesh.grid, scalars=overall_data, **kwargs_in)
 
+        background = kwargs.pop("background", None)
         if background is not None:
             self._internal_plotter._plotter.set_background(background)
 
+        cpos = kwargs.pop("cpos", None)
         if cpos is not None:
             self._internal_plotter._plotter.camera_position = cpos
 
         # show result
+        return_cpos = kwargs.pop("return_cpos", None)
         if return_cpos is None:
             kwargs_in = _sort_supported_kwargs(
                 bound_method=self._internal_plotter._plotter.show,
@@ -748,7 +749,7 @@ class Plotter:
             version_to_reach = '0.32.0'
             meet_ver = meets_version(pv_version, version_to_reach)
             if meet_ver:
-                return self._internal_plotter._plotter.show(return_cpos=return_cpos)
+                return self._internal_plotter._plotter.show(return_cpos=return_cpos, **kwargs_in)
             else:
                 txt = """To use the return_cpos option, please upgrade
                 your pyvista module with a version higher than """

--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -67,7 +67,7 @@ class _PyVistaPlotter:
             )
         # Filter kwargs
         kwargs_in = _sort_supported_kwargs(
-            bound_method=pv.Plotter,
+            bound_method=pv.Plotter.__init__,
             **kwargs)
         # Initiate pyvista Plotter
         self._plotter = pv.Plotter(**kwargs_in)

--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -738,10 +738,10 @@ class Plotter:
 
         # show result
         return_cpos = kwargs.pop("return_cpos", None)
+        kwargs_in = _sort_supported_kwargs(
+            bound_method=self._internal_plotter._plotter.show,
+            **kwargs)
         if return_cpos is None:
-            kwargs_in = _sort_supported_kwargs(
-                bound_method=self._internal_plotter._plotter.show,
-                **kwargs)
             return self._internal_plotter._plotter.show(**kwargs_in)
         else:
             import pyvista as pv

--- a/ansys/dpf/core/plotter.py
+++ b/ansys/dpf/core/plotter.py
@@ -601,10 +601,7 @@ class Plotter:
     def plot_contour(
             self,
             field_or_fields_container,
-            notebook=None,
             shell_layers=None,
-            off_screen=None,
-            show_axes=True,
             meshed_region=None,
             **kwargs
     ):
@@ -617,20 +614,9 @@ class Plotter:
         ----------
         field_or_fields_container : dpf.core.Field or dpf.core.FieldsContainer
             Field or field container that contains the result to plot.
-        notebook : bool, optional
-            Whether to plot a static image within an iPython notebook
-            if available. The default is `None`, in which case an attempt is
-            made to plot a static imaage within an iPython notebook. When ``False``,
-            a plot external to the notebook is generated with an interactive window.
-            When ``True``, a plot is always generated within a notebook.
         shell_layers : core.shell_layers, optional
             Enum used to set the shell layers if the model to plot
             contains shell elements.
-        off_screen : bool, optional
-            Whether to render off screen, which is useful for automated
-            screenshots. The default is ``None``.
-        show_axes : bool, optional
-            Whether to show a VTK axes widget. The default is ``True``.
         **kwargs : optional
             Additional keyword arguments for the plotter. For more information,
             see ``help(pyvista.plot)``.
@@ -730,12 +716,6 @@ class Plotter:
         cpos = kwargs.pop("cpos", None)
         return_cpos = kwargs.pop("return_cpos", None)
 
-        # plotter = pv.Plotter(notebook=notebook, off_screen=off_screen)
-        if notebook is not None:
-            self._internal_plotter._plotter.notebook = notebook
-        if off_screen is not None:
-            self._internal_plotter._plotter.off_screen = off_screen
-
         # add meshes
         kwargs.setdefault("show_edges", True)
         kwargs.setdefault("nan_color", "grey")
@@ -757,8 +737,6 @@ class Plotter:
             self._internal_plotter._plotter.camera_position = cpos
 
         # show result
-        if show_axes:
-            self._internal_plotter._plotter.add_axes()
         if return_cpos is None:
             kwargs_in = _sort_supported_kwargs(
                 bound_method=self._internal_plotter._plotter.show,

--- a/examples/05-plotting/00-basic_plotting.py
+++ b/examples/05-plotting/00-basic_plotting.py
@@ -10,14 +10,18 @@ shown with the arguments available.
 
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
-# from ansys.dpf.core.plotter import plot_chart
 
 
 # Plot the bare mesh of a model
 model = dpf.Model(examples.multishells_rst)
 model.plot(color="w", show_edges=True, title='Model', text='Model plot')
 # # Additional PyVista kwargs are supported, such as:
-model.plot(off_screen=True, screenshot='model_plot.png', title='Model', text='Model plot')
+model.plot(off_screen=True, notebook=False, screenshot='model_plot.png',
+           title='Model', text='Model plot')
+
+# Notes:
+# - To make screenshots, use "screenshot" as well as "notebook=False" if on a Jupyter notebook.
+# - The "off_screen" keyword only works when "notebook=False" to prevent the GUI from appearing.
 
 
 # Plot a field on its supporting mesh (field location must be Elemental or Nodal)
@@ -27,14 +31,16 @@ fc = stress.outputs.fields_container()
 field = fc[0]
 field.plot(notebook=False, shell_layers=None, show_axes=True, title='Field', text='Field plot')
 # # Additional PyVista kwargs are supported, such as:
-field.plot(off_screen=True, screenshot='field_plot.png', title='Field', text='Field plot off')
+field.plot(off_screen=True, notebook=False, screenshot='field_plot.png',
+           title='Field', text='Field plot off')
 #
 # # Alternatively one can plot the MeshedRegion associated to the model
 mesh = model.metadata.meshed_region
 mesh.plot(field_or_fields_container=None, shell_layers=None, show_axes=True,
           title='Mesh fc None', text='Mesh plot')
 # Additional PyVista kwargs are supported, such as:
-mesh.plot(off_screen=True, screenshot='mesh_plot.png', title='Mesh', text='Mesh plot off')
+mesh.plot(off_screen=True, notebook=False, screenshot='mesh_plot.png',
+          title='Mesh', text='Mesh plot off')
 # A fields_container or a specific field can be given to plot on the mesh.
 mesh.plot(field_or_fields_container=fc, title='Mesh with fields container', text='Mesh fc plot')
 mesh.plot(field_or_fields_container=field, title='Mesh with field', text='Mesh field plot')
@@ -53,5 +59,5 @@ disp_op.connect(4, ds)
 disp_fc = disp_op.outputs.fields_container()
 meshes_cont.plot(disp_fc, title='Meshes Container disp_fc', text='Meshes Container disp_fc plot')
 # Additional PyVista kwargs are supported, such as:
-meshes_cont.plot(off_screen=True, screenshot='meshes_cont_plot.png',
+meshes_cont.plot(off_screen=True, notebook=False, screenshot='meshes_cont_plot.png',
                  title='Meshes Container', text='Meshes Container plot')

--- a/examples/05-plotting/00-basic_plotting.py
+++ b/examples/05-plotting/00-basic_plotting.py
@@ -17,7 +17,7 @@ model = dpf.Model(examples.multishells_rst)
 model.plot(color="w", show_edges=True, title='Model', text='Model plot')
 # # Additional PyVista kwargs are supported, such as:
 model.plot(off_screen=True, notebook=False, screenshot='model_plot.png',
-           title='Model', text='Model plot')
+           title='Model', text='Model plot off')
 
 # Notes:
 # - To make screenshots, use "screenshot" as well as "notebook=False" if on a Jupyter notebook.


### PR DESCRIPTION
When in a Jupyter notebook, the notebook=False argument was not working when using a plot command going through Plotter.plot_contour