### PR TITLE
Ci/add concurrency-add back feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -28,7 +28,7 @@ body:
       label: Steps for implementing the feature
       placeholder: Describe how this new feature can be implemented
     validations:
-      required: true
+      required: false
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,43 @@
+name: 💡 New feature
+description: Enhancements to the code
+title: "Add ..."
+labels: ["enhancement"]
+assignees: [""]
+
+body:
+
+  - type: markdown
+    attributes:
+      value: '# 📝 **New Feature**'
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Description of the feature
+      placeholder: Describe what feature you devised and why it is useful for the project
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: '# 💡 **Implementation**'
+
+  - type: textarea
+    id: implementation-description
+    attributes:
+      label: Steps for implementing the feature
+      placeholder: Describe how this new feature can be implemented
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: '# 🔗 **References**'
+
+  - type: textarea
+    id: references
+    attributes:
+      label: Useful links and references
+      placeholder: A list of links and references to help when implementing the feature
+    validations:
+      required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
       - master
       - "release*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   PYANSYS_OFF_SCREEN: True
   DPF_PORT: 32772

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -12,6 +12,10 @@ on:
       - master
       - "release*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Adding concurrency to workflow runs so that a commit to a PR will run the associated workflows while cancelling the ones still running from the previous commit. Same for pushes to tagged branches.

Also adding back the feature issue template. Apparently having a custom bug.yml meant the organization's template for feature was not used either.