### PR TITLE
Build and Test using pydpf-actions - generate wheelhouse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,83 +42,10 @@ jobs:
           dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
           install_extras: plotting
 
-#      - name: "Test Package"
-#        uses: pyansys/pydpf-actions/test_package@v2.0
-#        with:
-#          MODULE: ${{env.MODULE}}
-
-####################################################################
-
-      - name: Install OpenGL
-        run: |
-          Set-StrictMode -Version Latest
-          $ErrorActionPreference = "Stop"
-          $PSDefaultParameterValues['*:ErrorAction']='Stop'
-          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
-          powershell gl-ci-helpers/appveyor/install_opengl.ps1
-
-      - name: Install test offscreen rendering
-        run: |
-          .ci/setup_headless_display.sh
-          pip install -r .ci/requirements_test_xvfb.txt
-          python .ci/display_test.py
-
-      - name: Install Test Environment
-        run: |
-          pip install -r requirements_test.txt
-        if: always()
-
-      - name: Test API Docstrings
-        run: |
-           pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys/dpf/core
-
-      - name: Kill all servers
-        shell: cmd
-        run: |
-          tasklist /FI "IMAGENAME eq Ans.Dpf.Grpc.exe" 2>NUL | find /I /N "Ans.Dpf.Grpc.exe">NUL
-          ECHO %ERRORLEVEL%
-          if "%ERRORLEVEL%"=="0"(taskkill /f /im Ans.Dpf.Grpc.exe)
-        continue-on-error: true
-
-      - name: Publish Doc Test Results
-        uses: actions/upload-artifact@v2
+      - name: "Test Package"
+        uses: pyansys/pydpf-actions/test_package@v2.0
         with:
-          name: ansys_dpf_core_doctest
-          path: junit/test-doctests-results.xml
-        if: always()
-
-      - name: Test Core API
-        run: |
-          cd tests
-          New-Item -Path ".\..\" -Name "local_server_test" -ItemType "directory"
-          Copy-Item -Path ".\test_local_server.py",".\test_multi_server.py", ".\test_workflow.py" -Destination ".\..\local_server_test\"
-          Copy-Item -Path ".\conftest.py" -Destination ".\..\local_server_test\conftest.py"
-          Remove-Item -Path ".\test_local_server.py",".\test_multi_server.py", ".\test_workflow.py"
-          pytest --cov=ansys.dpf.core --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results1.xml --reruns 2 .
-
-      - name: Test Core API 2
-        run: |
-          cd local_server_test
-          pytest --cov=ansys.dpf.core --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=../tests/junit/test-results2.xml --reruns 2 .
-        timeout-minutes: 10
-
-      - name: Kill all servers
-        shell: cmd
-        run: |
-          tasklist /FI "IMAGENAME eq Ans.Dpf.Grpc.exe" 2>NUL | find /I /N "Ans.Dpf.Grpc.exe">NUL
-          ECHO %ERRORLEVEL%
-          if "%ERRORLEVEL%"=="0"(taskkill /f /im Ans.Dpf.Grpc.exe)
-        continue-on-error: true
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-
-      - name: Publish Test Results
-        uses: actions/upload-artifact@v2
-        with:
-          name: ansys_dpf_core_pytest
-          path: tests/junit/test-results*.xml
-        if: always()
+          MODULE: ${{env.MODULE}}
 
       - name: 'Upload to PyPi'
         if: contains(github.ref, 'refs/tags')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8"]
-        os: ["windows-latest", "ubuntu-latest"]
+        os: ["windows-latest"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   Build_and_Test:
-    name: WindowsBuild and Test
+    name: Build and Test
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           install_extras: plotting
 
       - name: "Test Package"
-        uses: pyansys/pydpf-actions/test_package@v2.0
+        uses: pyansys/pydpf-actions/test_package@v2.1
         with:
           MODULE: ${{env.MODULE}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,59 +9,45 @@ on:
       - "*"
     branches:
       - master
-      - "release*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
-  PYANSYS_OFF_SCREEN: True
-  DPF_PORT: 32772
+  PACKAGE_NAME: ansys-dpf-core
+  MODULE: core
+  ANSYS_VERSION: 221
 
 jobs:
-  test_windows:
-    name: Windows
-    runs-on: windows-2019
-
-    env:
-      ANSYS_VERSION: 221
+  Build_and_Test:
+    name: WindowsBuild and Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8"]
+        os: ["windows-latest", "ubuntu-latest"]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Python
-        uses: actions/setup-python@v2.1.4
+      - name: "Build Package"
+        uses: pyansys/pydpf-actions/build_package@v2.1
         with:
-          python-version: 3.8
-
-      - id: install-dpf 
-        uses: pyansys/pydpf-actions/install-dpf-server@v1
-        with:
+          python-version: ${{ matrix.python-version }}
+          ANSYS_VERSION: ${{env.ANSYS_VERSION}}
+          PACKAGE_NAME: ${{env.PACKAGE_NAME}}
+          MODULE: ${{env.MODULE}}
           dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
-          ANSYS_VERSION : ${{env.ANSYS_VERSION}}
+          install_extras: plotting
 
-      - name: Set AWP_ROOT$env:ANSYS_VERSION
-        run: |
-          echo AWP_ROOT$env:ANSYS_VERSION
-          echo "AWP_ROOT$env:ANSYS_VERSION=${{ steps.install-dpf.outputs.SERVER }}"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+#      - name: "Test Package"
+#        uses: pyansys/pydpf-actions/test_package@v2.0
+#        with:
+#          MODULE: ${{env.MODULE}}
 
-      - name: Install ansys-dpf-core
-        shell: cmd
-        run: |
-          pip install -r requirements_build.txt
-          python setup.py bdist_wheel
-          FOR /F %%a in ('dir /s/b dist\*.whl') do SET WHEELPATH=%%a
-          ECHO %WHEELPATH%
-          cd tests
-          pip install %WHEELPATH%
-          python -c "from ansys.dpf import core; print(core.Report(gpu=False))"
-
-      - name: WHEEL publish artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ansys_dpf_core_wheel
-          path: ./dist/*
+####################################################################
 
       - name: Install OpenGL
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - "*"
     branches:
       - master
+      - "release*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This will add wheelhouse generation and facilitate the release process and testing for several Python versions.
For now only building and testing Windows with Python 3.8 as per previous behavior.