### PR TITLE
Feat/new setters for nodes elements and meshedregion

### DIFF
--- a/ansys/dpf/core/elements.py
+++ b/ansys/dpf/core/elements.py
@@ -12,6 +12,7 @@ from ansys.dpf.core import nodes, scoping
 from ansys.dpf.core.common import __write_enum_doc__, locations, elemental_properties
 from ansys.dpf.core.element_descriptor import ElementDescriptor
 from ansys.dpf.core.errors import protect_grpc
+from ansys.dpf.core.check_version import version_requires
 
 
 class Element:
@@ -492,6 +493,22 @@ class Elements:
 
         """
         return self._mesh.field_of_properties(elemental_properties.element_type)
+
+    @element_types_field.setter
+    @version_requires("3.0")
+    def element_types_field(self, property_field):
+        """Element types field setter.
+
+        Parameters
+        ----------
+        property_field : PropertyField
+            PropertyField that contains element type values
+        """
+        request = meshed_region_pb2.SetFieldRequest()
+        request.mesh.CopyFrom(self._mesh._message)
+        request.property_type.property_name.property_name = elemental_properties.element_type
+        request.field.CopyFrom(property_field._message)
+        self._mesh._stub.SetField(request)
 
     @property
     @protect_grpc

--- a/ansys/dpf/core/elements.py
+++ b/ansys/dpf/core/elements.py
@@ -494,6 +494,14 @@ class Elements:
         """
         return self._mesh.field_of_properties(elemental_properties.element_type)
 
+    @protect_grpc
+    def _property_field_setter(self, property_field, property_type):
+        request = meshed_region_pb2.SetFieldRequest()
+        request.mesh.CopyFrom(self._mesh._message)
+        request.property_type.property_name.property_name = property_type
+        request.field.CopyFrom(property_field._message)
+        self._mesh._stub.SetField(request)
+
     @element_types_field.setter
     @version_requires("3.0")
     def element_types_field(self, property_field):
@@ -504,11 +512,7 @@ class Elements:
         property_field : PropertyField
             PropertyField that contains element type values
         """
-        request = meshed_region_pb2.SetFieldRequest()
-        request.mesh.CopyFrom(self._mesh._message)
-        request.property_type.property_name.property_name = elemental_properties.element_type
-        request.field.CopyFrom(property_field._message)
-        self._mesh._stub.SetField(request)
+        self._property_field_setter(property_field, elemental_properties.element_type)
 
     @property
     @protect_grpc
@@ -544,11 +548,7 @@ class Elements:
         property_field : PropertyField
             PropertyField that contains materials value
         """
-        request = meshed_region_pb2.SetFieldRequest()
-        request.mesh.CopyFrom(self._mesh._message)
-        request.property_type.property_name.property_name = elemental_properties.material
-        request.field.CopyFrom(property_field._message)
-        self._mesh._stub.SetField(request)
+        self._property_field_setter(property_field, elemental_properties.material)
 
     @property
     def connectivities_field(self):
@@ -588,11 +588,7 @@ class Elements:
         property_field : PropertyField
             PropertyField that contains connectivity value
         """
-        request = meshed_region_pb2.SetFieldRequest()
-        request.mesh.CopyFrom(self._mesh._message)
-        request.property_type.property_name.property_name = elemental_properties.connectivity
-        request.field.CopyFrom(property_field._message)
-        self._mesh._stub.SetField(request)
+        self._property_field_setter(property_field, elemental_properties.connectivity)
 
     @property
     def n_elements(self) -> int:

--- a/ansys/dpf/core/elements.py
+++ b/ansys/dpf/core/elements.py
@@ -578,6 +578,22 @@ class Elements:
         """Retrieve the connectivities field."""
         return self._mesh.field_of_properties(elemental_properties.connectivity)
 
+    @connectivities_field.setter
+    @version_requires("3.0")
+    def connectivities_field(self, property_field):
+        """Connectivity field setter.
+
+        Parameters
+        ----------
+        property_field : PropertyField
+            PropertyField that contains connectivity value
+        """
+        request = meshed_region_pb2.SetFieldRequest()
+        request.mesh.CopyFrom(self._mesh._message)
+        request.property_type.property_name.property_name = elemental_properties.connectivity
+        request.field.CopyFrom(property_field._message)
+        self._mesh._stub.SetField(request)
+
     @property
     def n_elements(self) -> int:
         """Number of elements"""

--- a/ansys/dpf/core/elements.py
+++ b/ansys/dpf/core/elements.py
@@ -16,7 +16,8 @@ from ansys.dpf.core.check_version import version_requires
 
 
 class Element:
-    """Contains all properties of an element of a mesh.
+    """
+    Contains all properties of an element of a mesh.
 
     The element is created from the
     :class:`MeshedRegion <ansys.dpf.core.meshed_region.MeshedRegion>` class.
@@ -58,7 +59,8 @@ class Element:
 
     @property
     def node_ids(self):
-        """IDs of all nodes in the element.
+        """
+        IDs of all nodes in the element.
 
         Returns
         --------
@@ -80,7 +82,8 @@ class Element:
 
     @property
     def id(self) -> int:
-        """ID of the element.
+        """
+        ID of the element.
 
         Returns
         -------
@@ -92,7 +95,8 @@ class Element:
 
     @property
     def index(self) -> int:
-        """Index of the element in the result.
+        """
+        Index of the element in the result.
 
         Returns
         -------
@@ -104,7 +108,8 @@ class Element:
 
     @property
     def nodes(self):
-        """All nodes in the element.
+        """
+        All nodes in the element.
         Returns
         --------
         list
@@ -124,7 +129,8 @@ class Element:
 
     @property
     def n_nodes(self) -> int:
-        """Number of nodes in the element.
+        """
+        Number of nodes in the element.
 
         Returns
         -------
@@ -144,7 +150,8 @@ class Element:
 
     @property
     def type(self) -> int:
-        """Type of the element.
+        """
+        Type of the element.
 
         Returns
         -------
@@ -172,7 +179,8 @@ class Element:
 
     @property
     def shape(self) -> str:
-        """Shape of the element.
+        """
+        Shape of the element.
 
         Returns
         -------
@@ -217,7 +225,8 @@ class Element:
 
     @property
     def connectivity(self):
-        """Ordered list of node indices of the element.
+        """
+        Ordered list of node indices of the element.
 
         Returns
         --------
@@ -232,7 +241,8 @@ class Element:
 
 
 class Elements:
-    """Contains elements belonging to a meshed region.
+    """
+    Contains elements belonging to a meshed region.
 
     Parameters
     ----------
@@ -270,7 +280,8 @@ class Elements:
             yield self[i]
 
     def element_by_id(self, id) -> Element:
-        """Retrieve an element by element ID.
+        """
+        Retrieve an element by element ID.
 
         Parameters
         ----------
@@ -286,7 +297,8 @@ class Elements:
         return self.__get_element(elementid=id)
 
     def element_by_index(self, index) -> Element:
-        """Retrieve an element using its index.
+        """
+        Retrieve an element using its index.
 
         Parameters
         ----------
@@ -310,7 +322,8 @@ class Elements:
         return self.__get_element(elementindex=index)
 
     def add_elements(self, num):
-        """Add one or more elements in the mesh.
+        """
+        Add one or more elements in the mesh.
 
         Parameters
         ----------
@@ -352,7 +365,8 @@ class Elements:
         self._mesh._stub.Add(request)
 
     def add_solid_element(self, id, connectivity):
-        """Add a solid 3D element in the mesh.
+        """
+        Add a solid 3D element in the mesh.
 
         Parameters
         ----------
@@ -364,7 +378,8 @@ class Elements:
         self.add_element(id, "solid", connectivity)
 
     def add_shell_element(self, id, connectivity):
-        """Add a shell 2D element in the mesh.
+        """
+        Add a shell 2D element in the mesh.
 
         Parameters
         ----------
@@ -376,7 +391,8 @@ class Elements:
         self.add_element(id, "shell", connectivity)
 
     def add_beam_element(self, id, connectivity):
-        """Add a beam 1D element in the mesh.
+        """
+        Add a beam 1D element in the mesh.
 
         Parameters
         ----------
@@ -389,7 +405,8 @@ class Elements:
         self.add_element(id, "beam", connectivity)
 
     def add_point_element(self, id, connectivity):
-        """Add a point element (one node connectivity) in the mesh.
+        """
+        Add a point element (one node connectivity) in the mesh.
 
         Parameters
         ----------
@@ -404,7 +421,8 @@ class Elements:
         self.add_element(id, "unknown_shape", connectivity)
 
     def add_element(self, id, shape, connectivity):
-        """Add an element in the mesh.
+        """
+        Add an element in the mesh.
 
         Parameters
         ----------
@@ -426,7 +444,8 @@ class Elements:
 
     @protect_grpc
     def __get_element(self, elementindex=None, elementid=None):
-        """Retrieve the element by ID or index.
+        """
+        Retrieve the element by ID or index.
 
         Parameters
         ----------
@@ -456,7 +475,8 @@ class Elements:
 
     @property
     def scoping(self) -> scoping.Scoping:
-        """Scoping of the elements.
+        """
+        Scoping of the elements.
 
         Returns
         -------
@@ -475,7 +495,8 @@ class Elements:
 
     @property
     def element_types_field(self):
-        """Field of all element types.
+        """
+        Field of all element types.
 
         Returns
         -------
@@ -506,7 +527,8 @@ class Elements:
     @element_types_field.setter
     @version_requires("3.0")
     def element_types_field(self, property_field):
-        """Element types field setter.
+        """
+        Element types field setter.
 
         Parameters
         ----------
@@ -518,7 +540,8 @@ class Elements:
     @property
     @protect_grpc
     def materials_field(self):
-        """Field of all material IDs.
+        """
+        Field of all material IDs.
 
         Returns
         -------
@@ -542,7 +565,8 @@ class Elements:
     @materials_field.setter
     @version_requires("3.0")
     def materials_field(self, property_field):
-        """Materials field setter.
+        """
+        Materials field setter.
 
         Parameters
         ----------
@@ -553,7 +577,8 @@ class Elements:
 
     @property
     def connectivities_field(self):
-        """Field containing for each element ID the node indices connected to the element.
+        """
+        Field containing for each element ID the node indices connected to the element.
 
         Returns
         -------
@@ -582,7 +607,8 @@ class Elements:
     @connectivities_field.setter
     @version_requires("3.0")
     def connectivities_field(self, property_field):
-        """Connectivity field setter.
+        """
+        Connectivity field setter.
 
         Parameters
         ----------
@@ -602,7 +628,8 @@ class Elements:
 
     @property
     def mapping_id_to_index(self) -> dict:
-        """Mapping between the IDs and indices of the entity.
+        """
+        Mapping between the IDs and indices of the entity.
 
         This proprty is useful for mapping scalar results from a field to the meshed region.
 
@@ -620,7 +647,8 @@ class Elements:
         return self._mapping_id_to_index
 
     def map_scoping(self, external_scope):
-        """Retrieve the indices to map the scoping of these elements to
+        """
+        Retrieve the indices to map the scoping of these elements to
         the scoping of a field.
 
         Parameters
@@ -660,7 +688,8 @@ class Elements:
 
     @property
     def has_shell_elements(self) -> bool:
-        """Whether at least one element is a 2D element (shell).
+        """
+        Whether at least one element is a 2D element (shell).
 
         Returns
         -------
@@ -673,7 +702,8 @@ class Elements:
 
     @property
     def has_solid_elements(self) -> bool:
-        """Whether at list one element is a 3D element (solid).
+        """
+        Whether at list one element is a 3D element (solid).
 
         Returns
         -------
@@ -686,7 +716,8 @@ class Elements:
 
     @property
     def has_beam_elements(self) -> bool:
-        """Whether at least one element is a 1D beam element.
+        """
+        Whether at least one element is a 1D beam element.
 
         Returns
         -------
@@ -699,7 +730,8 @@ class Elements:
 
     @property
     def has_point_elements(self) -> bool:
-        """Whether at least one element is a point element.
+        """
+        Whether at least one element is a point element.
 
         Returns
         -------
@@ -712,7 +744,8 @@ class Elements:
 
 
 class ElementAdder:
-    """Provides for adding new elements in a meshed region.
+    """
+    Provides for adding new elements in a meshed region.
 
     Parameters
     ----------
@@ -754,7 +787,8 @@ class ElementAdder:
 
     @property
     def is_solid(self) -> bool:
-        """Whether the element is a solid.
+        """
+        Whether the element is a solid.
 
         Returns
         -------
@@ -771,7 +805,8 @@ class ElementAdder:
 
     @property
     def is_shell(self) -> bool:
-        """Whether the element is a shell.
+        """
+        Whether the element is a shell.
 
         Returns
         -------
@@ -788,7 +823,8 @@ class ElementAdder:
 
     @property
     def is_beam(self) -> bool:
-        """Whether the element is a beam.
+        """
+        Whether the element is a beam.
 
         Returns
         -------
@@ -805,7 +841,8 @@ class ElementAdder:
 
     @property
     def is_point(self) -> bool:
-        """Whether the element is a point.
+        """
+        Whether the element is a point.
 
         Returns
         -------
@@ -822,7 +859,8 @@ class ElementAdder:
 
     @property
     def shape(self) -> str:
-        """Shape of the element.
+        """
+        Shape of the element.
 
         Returns
         --------
@@ -842,7 +880,8 @@ class ElementAdder:
 
     @shape.setter
     def shape(self, value):
-        """Set the shape of the element.
+        """
+        Set the shape of the element.
 
         Parameters
         --------
@@ -1236,7 +1275,8 @@ class element_types(Enum):
 
     @staticmethod
     def shape(element_type):
-        """Retrieve the shape of the element.
+        """
+        Retrieve the shape of the element.
 
         Returns
         -------
@@ -1250,7 +1290,8 @@ class element_types(Enum):
 
     @staticmethod
     def descriptor(element_type):
-        """Retrieve element information.
+        """
+        Retrieve element information.
 
         This method provides access to an instance of the ``ElementDescriptor`` of the requested
         element to retrieve such information as the number of nodes and shape.

--- a/ansys/dpf/core/elements.py
+++ b/ansys/dpf/core/elements.py
@@ -252,6 +252,7 @@ class Elements:
 
     def __init__(self, mesh):
         self._mesh = mesh
+        self._server = self._mesh._server
         self._mapping_id_to_index = None
 
     def __str__(self):

--- a/ansys/dpf/core/elements.py
+++ b/ansys/dpf/core/elements.py
@@ -534,6 +534,22 @@ class Elements:
         """
         return self._mesh.field_of_properties(elemental_properties.material)
 
+    @materials_field.setter
+    @version_requires("3.0")
+    def materials_field(self, property_field):
+        """Materials field setter.
+
+        Parameters
+        ----------
+        property_field : PropertyField
+            PropertyField that contains materials value
+        """
+        request = meshed_region_pb2.SetFieldRequest()
+        request.mesh.CopyFrom(self._mesh._message)
+        request.property_type.property_name.property_name = elemental_properties.material
+        request.field.CopyFrom(property_field._message)
+        self._mesh._stub.SetField(request)
+
     @property
     def connectivities_field(self):
         """Field containing for each element ID the node indices connected to the element.

--- a/ansys/dpf/core/meshed_region.py
+++ b/ansys/dpf/core/meshed_region.py
@@ -242,6 +242,23 @@ class MeshedRegion:
         else:
             return field.Field(server=self._server, field=fieldOut)
 
+    @version_requires("3.0")
+    def set_property_field(self, property_name, value):
+        """Property field setter. It can be coordinates (field),
+        element types (property field)...
+
+        Parameters
+        ----------
+        property_name : str
+            property name of the field to set
+        value : PropertyField or Field
+        """
+        request = meshed_region_pb2.SetFieldRequest()
+        request.mesh.CopyFrom(self._message)
+        request.property_type.property_name.property_name = property_name
+        request.field.CopyFrom(value._message)
+        self._stub.SetField(request)
+
     @property
     def available_named_selections(self):
         """List of available named selections.

--- a/ansys/dpf/core/meshed_region.py
+++ b/ansys/dpf/core/meshed_region.py
@@ -4,19 +4,19 @@ MeshedRegion
 """
 from ansys import dpf
 from ansys.dpf.core import scoping, field, property_field
-from ansys.dpf.core.check_version import server_meet_version
+from ansys.dpf.core.check_version import server_meet_version, version_requires
 from ansys.dpf.core.common import locations, types, nodal_properties, elemental_properties
 from ansys.dpf.core.elements import Elements, element_types
 from ansys.dpf.core.nodes import Nodes
 from ansys.dpf.core.plotter import DpfPlotter, Plotter
 from ansys.dpf.core.cache import class_handling_cache
 from ansys.grpc.dpf import meshed_region_pb2, meshed_region_pb2_grpc
-from ansys.dpf.core.check_version import server_meet_version, version_requires
 
 
 @class_handling_cache
 class MeshedRegion:
-    """Represents a mesh from DPF.
+    """
+    Represents a mesh from DPF.
 
     Parameters
     ----------
@@ -111,7 +111,8 @@ class MeshedRegion:
 
     @property
     def elements(self):
-        """All elemental properties of the mesh, such as connectivity and element types.
+        """
+        All elemental properties of the mesh, such as connectivity and element types.
 
         Returns
         -------
@@ -135,7 +136,8 @@ class MeshedRegion:
 
     @property
     def nodes(self):
-        """All nodal properties of the mesh, such as node coordinates and nodal connectivity.
+        """
+        All nodal properties of the mesh, such as node coordinates and nodal connectivity.
 
         Returns
         -------
@@ -159,7 +161,8 @@ class MeshedRegion:
 
     @property
     def unit(self):
-        """Unit of the meshed region.
+        """
+        Unit of the meshed region.
 
         This unit is the same as the unit of the coordinates of the meshed region.
 
@@ -171,7 +174,8 @@ class MeshedRegion:
 
     @unit.setter
     def unit(self, value):
-        """Unit type.
+        """
+        Unit type.
 
         Parameters
         ----------
@@ -180,7 +184,8 @@ class MeshedRegion:
         return self._set_unit(value)
 
     def _get_unit(self):
-        """Retrieve the unit type.
+        """
+        Retrieve the unit type.
 
         Returns
         -------
@@ -189,7 +194,8 @@ class MeshedRegion:
         return self._stub.List(self._message).unit
 
     def _set_unit(self, unit):
-        """Set the unit of the meshed region.
+        """
+        Set the unit of the meshed region.
 
         Parameters
         ----------
@@ -217,7 +223,8 @@ class MeshedRegion:
 
     @property
     def available_property_fields(self):
-        """Returns a list of available property fields
+        """
+        Returns a list of available property fields
 
         Returns
         -------
@@ -226,7 +233,8 @@ class MeshedRegion:
         return self._stub.List(self._message).available_prop
 
     def property_field(self, property_name):
-        """Property field getter. It can be coordinates (field),
+        """
+        Property field getter. It can be coordinates (field),
         element types (property field)...
 
         Returns
@@ -244,7 +252,8 @@ class MeshedRegion:
 
     @version_requires("3.0")
     def set_property_field(self, property_name, value):
-        """Property field setter. It can be coordinates (field),
+        """
+        Property field setter. It can be coordinates (field),
         element types (property field)...
 
         Parameters
@@ -261,7 +270,8 @@ class MeshedRegion:
 
     @property
     def available_named_selections(self):
-        """List of available named selections.
+        """
+        List of available named selections.
 
         Returns
         -------
@@ -270,7 +280,8 @@ class MeshedRegion:
         return self._get_available_named_selections()
 
     def _get_available_named_selections(self):
-        """List of available named selections.
+        """
+        List of available named selections.
 
         Returns
         -------
@@ -284,7 +295,8 @@ class MeshedRegion:
             return self._stub.List(self._message).named_selections
 
     def named_selection(self, named_selection):
-        """Scoping containing the list of nodes or elements in the named selection.
+        """
+        Scoping containing the list of nodes or elements in the named selection.
 
         Parameters
         ----------
@@ -317,7 +329,8 @@ class MeshedRegion:
 
     @version_requires("3.0")
     def set_named_selection_scoping(self, named_selection_name, scoping):
-        """Named selection scoping setter.
+        """
+        Named selection scoping setter.
 
         Parameters
         ----------
@@ -376,7 +389,8 @@ class MeshedRegion:
     #     return MeshedRegion(self._server.channel, skin, self._model, name)
 
     def deform_by(self, deform_by, scale_factor=1.):
-        """Deforms the mesh according to a 3D vector field and an additional scale factor.
+        """
+        Deforms the mesh according to a 3D vector field and an additional scale factor.
 
         Parameters
         ----------
@@ -424,7 +438,8 @@ class MeshedRegion:
 
     @property
     def grid(self):
-        """Unstructured grid in VTK format from PyVista.
+        """
+        Unstructured grid in VTK format from PyVista.
 
         Returns
         -------
@@ -460,7 +475,8 @@ class MeshedRegion:
             scale_factor=1.0,
             **kwargs
     ):
-        """Plot the field or fields container on the mesh.
+        """
+        Plot the field or fields container on the mesh.
 
         Parameters
         ----------
@@ -503,7 +519,8 @@ class MeshedRegion:
         return pl.show_figure(**kwargs)
 
     def deep_copy(self, server=None):
-        """Create a deep copy of the meshed region's data on a given server.
+        """
+        Create a deep copy of the meshed region's data on a given server.
 
         This method is useful for passing data from one server instance to another.
 
@@ -560,7 +577,8 @@ class MeshedRegion:
         self._message = self._stub.Create(request)
 
     def field_of_properties(self, property_name):
-        """Returns the ``Field`` or ``PropertyField`` associated
+        """
+        Returns the ``Field`` or ``PropertyField`` associated
         to a given property of the mesh
 
         Parameters

--- a/ansys/dpf/core/meshed_region.py
+++ b/ansys/dpf/core/meshed_region.py
@@ -11,6 +11,8 @@ from ansys.dpf.core.nodes import Nodes
 from ansys.dpf.core.plotter import DpfPlotter, Plotter
 from ansys.dpf.core.cache import class_handling_cache
 from ansys.grpc.dpf import meshed_region_pb2, meshed_region_pb2_grpc
+from ansys.dpf.core.check_version import server_meet_version, version_requires
+
 
 @class_handling_cache
 class MeshedRegion:
@@ -268,6 +270,22 @@ class MeshedRegion:
                     "only implemented for meshed region created from a "
                     "model for server version 2.0. Please update your server."
                 )
+
+    @version_requires("3.0")
+    def set_named_selection_scoping(self, named_selection_name, scoping):
+        """Named selection scoping setter.
+
+        Parameters
+        ----------
+        named_selection_name : str
+            named selection name
+        scoping : Scoping
+        """
+        request = meshed_region_pb2.SetNamedSelectionRequest()
+        request.mesh.CopyFrom(self._message)
+        request.named_selection = named_selection_name
+        request.scoping.CopyFrom(scoping._message)
+        self._stub.SetNamedSelection(request)
 
     def _set_stream_provider(self, stream_provider):
         self._stream_provider = stream_provider

--- a/ansys/dpf/core/meshed_region.py
+++ b/ansys/dpf/core/meshed_region.py
@@ -225,6 +225,23 @@ class MeshedRegion:
         """
         return self._stub.List(self._message).available_prop
 
+    def property_field(self, property_name):
+        """Property field getter. It can be coordinates (field),
+        element types (property field)...
+
+        Returns
+        -------
+        field_or_property_field : core.Field or core.PropertyField
+        """
+        request = meshed_region_pb2.ListPropertyRequest()
+        request.mesh.CopyFrom(self._message)
+        request.property_type.property_name.property_name = property_name
+        fieldOut = self._stub.ListProperty(request)
+        if fieldOut.datatype == u"int":
+            return property_field.PropertyField(server=self._server, property_field=fieldOut)
+        else:
+            return field.Field(server=self._server, field=fieldOut)
+
     @property
     def available_named_selections(self):
         """List of available named selections.

--- a/ansys/dpf/core/meshed_region.py
+++ b/ansys/dpf/core/meshed_region.py
@@ -216,6 +216,16 @@ class MeshedRegion:
         return _description(self._message, self._server)
 
     @property
+    def available_property_fields(self):
+        """Returns a list of available property fields
+
+        Returns
+        -------
+        available_property_fields : list str
+        """
+        return self._stub.List(self._message).available_prop
+
+    @property
     def available_named_selections(self):
         """List of available named selections.
 

--- a/ansys/dpf/core/nodes.py
+++ b/ansys/dpf/core/nodes.py
@@ -262,6 +262,22 @@ class Nodes:
         """
         return self._mesh.field_of_properties(nodal_properties.nodal_connectivity)
 
+    @nodal_connectivity_field.setter
+    @version_requires("3.0")
+    def nodal_connectivity_field(self, value):
+        """Connectivity field setter.
+
+        Parameters
+        ----------
+        value : PropertyField
+            PropertyField that contains nodal connectivity value
+        """
+        request = meshed_region_pb2.SetFieldRequest()
+        request.mesh.CopyFrom(self._mesh._message)
+        request.property_type.property_name.property_name = nodal_properties.nodal_connectivity
+        request.field.CopyFrom(value._message)
+        self._mesh._stub.SetField(request)
+
     @protect_grpc
     def _get_coordinates_field(self):
         """Retrieve the coordinates field."""

--- a/ansys/dpf/core/nodes.py
+++ b/ansys/dpf/core/nodes.py
@@ -13,7 +13,8 @@ from ansys.dpf.core.check_version import version_requires
 
 
 class Node:
-    """Encapsulates all properties of a node in the mesh.
+    """
+    Encapsulates all properties of a node in the mesh.
 
     A node is created from the :class:`ansys.dpf.core.elements` or
     :class:`ansys.dpf.core.meshed_region` class.
@@ -64,7 +65,8 @@ class Node:
 
     @property
     def coordinates(self):
-        """Cartesian coordinates of the node.
+        """
+        Cartesian coordinates of the node.
 
         Examples
         --------
@@ -80,7 +82,8 @@ class Node:
 
     @property
     def nodal_connectivity(self):
-        """Elements indices connected to the node.
+        """
+        Elements indices connected to the node.
 
         Returns
         -------
@@ -96,7 +99,8 @@ class Node:
 
 
 class Nodes:
-    """Provides a collection of DPF nodes.
+    """
+    Provides a collection of DPF nodes.
 
     Parameters
     ----------
@@ -144,7 +148,8 @@ class Nodes:
 
     @protect_grpc
     def __get_node(self, nodeindex=None, nodeid=None):
-        """Retrieves the node by its ID or index.
+        """
+        Retrieves the node by its ID or index.
 
         Parameters
         ----------
@@ -169,7 +174,8 @@ class Nodes:
 
     @property
     def scoping(self):
-        """Scoping of the nodes.
+        """
+        Scoping of the nodes.
 
         Returns
         -------
@@ -198,7 +204,8 @@ class Nodes:
 
     @property
     def coordinates_field(self):
-        """Coordinates field.
+        """
+        Coordinates field.
 
         Returns
         -------
@@ -232,7 +239,8 @@ class Nodes:
     @coordinates_field.setter
     @version_requires("3.0")
     def coordinates_field(self, property_field):
-        """Coordinates field setter.
+        """
+        Coordinates field setter.
 
         Parameters
         ----------
@@ -243,7 +251,8 @@ class Nodes:
 
     @property
     def nodal_connectivity_field(self):
-        """Nodal connectivity field
+        """
+        Nodal connectivity field
 
         Field containing each node ID for the elements indices
         connected to the given node.
@@ -283,7 +292,8 @@ class Nodes:
         return self._mapping_id_to_index
 
     def map_scoping(self, external_scope):
-        """Retrieve the indices to map the scoping of these elements to the scoping of a field.
+        """
+        Retrieve the indices to map the scoping of these elements to the scoping of a field.
 
         Parameters
         ----------
@@ -326,7 +336,8 @@ class Nodes:
         return ind, mask
 
     def add_node(self, id, coordinates):
-        """Add a node in the mesh.
+        """
+        Add a node in the mesh.
 
         Parameters
         ----------
@@ -343,7 +354,8 @@ class Nodes:
         self._mesh._stub.Add(request)
 
     def add_nodes(self, num):
-        """Add a number of nodes in the mesh.
+        """
+        Add a number of nodes in the mesh.
 
         This method yields a number of nodes that you can define.
 
@@ -377,7 +389,8 @@ class Nodes:
 
 
 class NodeAdder:
-    """Adds a new node to a meshed region.
+    """
+    Adds a new node to a meshed region.
 
     Attributes
     ----------

--- a/ansys/dpf/core/nodes.py
+++ b/ansys/dpf/core/nodes.py
@@ -267,18 +267,6 @@ class Nodes:
         """
         return self._mesh.field_of_properties(nodal_properties.nodal_connectivity)
 
-    @nodal_connectivity_field.setter
-    @version_requires("3.0")
-    def nodal_connectivity_field(self, property_field):
-        """Connectivity field setter.
-
-        Parameters
-        ----------
-        property_field : PropertyField
-            PropertyField that contains nodal connectivity value
-        """
-        self._property_field_setter(property_field, nodal_properties.nodal_connectivity)
-
     @protect_grpc
     def _get_coordinates_field(self):
         """Retrieve the coordinates field."""

--- a/ansys/dpf/core/nodes.py
+++ b/ansys/dpf/core/nodes.py
@@ -117,6 +117,7 @@ class Nodes:
 
     def __init__(self, mesh):
         self._mesh = mesh
+        self._server = self._mesh._server
         self._mapping_id_to_index = None
 
     def __str__(self):

--- a/ansys/dpf/core/nodes.py
+++ b/ansys/dpf/core/nodes.py
@@ -9,6 +9,7 @@ from ansys.grpc.dpf import meshed_region_pb2
 from ansys import dpf
 from ansys.dpf.core.common import nodal_properties
 from ansys.dpf.core.errors import protect_grpc
+from ansys.dpf.core.check_version import version_requires
 
 
 class Node:
@@ -218,6 +219,22 @@ class Nodes:
 
         """
         return self._get_coordinates_field()
+
+    @coordinates_field.setter
+    @version_requires("3.0")
+    def coordinates_field(self, value):
+        """Coordinates field setter.
+
+        Parameters
+        ----------
+        value : Field
+            Field that contains coordinates
+        """
+        request = meshed_region_pb2.SetFieldRequest()
+        request.mesh.CopyFrom(self._mesh._message)
+        request.property_type.property_name.property_name = nodal_properties.coordinates
+        request.field.CopyFrom(value._message)
+        self._mesh._stub.SetField(request)
 
     @property
     def nodal_connectivity_field(self):

--- a/ansys/dpf/core/nodes.py
+++ b/ansys/dpf/core/nodes.py
@@ -220,21 +220,25 @@ class Nodes:
         """
         return self._get_coordinates_field()
 
+    @protect_grpc
+    def _property_field_setter(self, property_field, property_type):
+        request = meshed_region_pb2.SetFieldRequest()
+        request.mesh.CopyFrom(self._mesh._message)
+        request.property_type.property_name.property_name = property_type
+        request.field.CopyFrom(property_field._message)
+        self._mesh._stub.SetField(request)
+
     @coordinates_field.setter
     @version_requires("3.0")
-    def coordinates_field(self, value):
+    def coordinates_field(self, property_field):
         """Coordinates field setter.
 
         Parameters
         ----------
-        value : Field
+        property_field : Field
             Field that contains coordinates
         """
-        request = meshed_region_pb2.SetFieldRequest()
-        request.mesh.CopyFrom(self._mesh._message)
-        request.property_type.property_name.property_name = nodal_properties.coordinates
-        request.field.CopyFrom(value._message)
-        self._mesh._stub.SetField(request)
+        self._property_field_setter(property_field, nodal_properties.coordinates)
 
     @property
     def nodal_connectivity_field(self):
@@ -264,19 +268,15 @@ class Nodes:
 
     @nodal_connectivity_field.setter
     @version_requires("3.0")
-    def nodal_connectivity_field(self, value):
+    def nodal_connectivity_field(self, property_field):
         """Connectivity field setter.
 
         Parameters
         ----------
-        value : PropertyField
+        property_field : PropertyField
             PropertyField that contains nodal connectivity value
         """
-        request = meshed_region_pb2.SetFieldRequest()
-        request.mesh.CopyFrom(self._mesh._message)
-        request.property_type.property_name.property_name = nodal_properties.nodal_connectivity
-        request.field.CopyFrom(value._message)
-        self._mesh._stub.SetField(request)
+        self._property_field_setter(property_field, nodal_properties.nodal_connectivity)
 
     @protect_grpc
     def _get_coordinates_field(self):

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -272,6 +272,12 @@ def test_connectivity_meshed_region():
     assert np.allclose(nodal_conne.get_entity_data_by_id(1), [0])
     assert np.allclose(mesh.nodes.node_by_id(1).nodal_connectivity, [0])
 
+    new_connectivity_data = nodal_conne.data
+    new_connectivity_data[0] = 1
+    nodal_conne.data = new_connectivity_data
+    mesh.nodes.nodal_connectivity_field = nodal_conne
+    assert np.allclose(nodal_conne.get_entity_data_by_id(1), [0])
+    assert np.allclose(mesh.nodes.node_by_id(1).nodal_connectivity, [0])
 
 
 def test_create_all_shaped_meshed_region():

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -45,14 +45,21 @@ def test_meshed_region_available_property_fields(simple_bar_model):
     assert mesh.available_property_fields == properties
 
 
-def test_get_element_type_meshedregion(simple_bar_model):
+def test_element_type_meshedregion(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region
     assert mesh.elements.element_by_index(1).type.value == 11
     assert mesh.elements.element_by_index(1).type == dpf.core.element_types.Hex8
     assert mesh.elements.element_by_index(1).shape == "solid"
 
-    types = mesh.property_field(dpf.core.common.elemental_properties.element_type).data
-    assert np.allclose(types, np.full_like(types, 11))
+    types = mesh.property_field(dpf.core.common.elemental_properties.element_type)
+    assert np.allclose(types.data, np.full_like(types.data, 11))
+
+    new_data = types.data
+    new_data[0] = 0
+    types.data = new_data
+    mesh.elements.element_types_field = types
+    types = mesh.elements.element_types_field
+    assert types.data[0] == 0
 
 
 def test_get_set_unit_meshedregion(simple_bar_model):

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -41,7 +41,7 @@ def test_vtk_grid_from_model(simple_bar_model):
 
 def test_meshed_region_available_property_fields(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region
-    properties = ['connectivity', 'elprops', 'eltype', 'apdl_element_type', 'section', 'mat']
+    properties = ['connectivity', 'elprops', 'eltype', 'apdl_element_type', 'mat']
     assert mesh.available_property_fields == properties
 
 

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -123,14 +123,14 @@ def test_get_materials_field_meshedregion(simple_bar_model):
 
 def test_get_connectivities_field_meshedregion(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region
-    elemcoping = mesh.elements.scoping
     field_connect = mesh.elements.connectivities_field
     assert field_connect.data[0] == 1053
     assert field_connect.component_count == 1
     assert np.allclose(
         field_connect.get_entity_data(1),
-        [1053, 1062, 1143, 1134, 2492, 2491, 2482, 2483],
-    )
+        [1053, 1062, 1143, 1134, 2492, 2491, 2482, 2483])
+    connectivity = mesh.property_field(dpf.core.common.elemental_properties.connectivity)
+    assert np.allclose(connectivity.data, field_connect.data)
 
 
 def test_get_nodes_meshedregion(simple_bar_model):

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -287,18 +287,6 @@ def test_set_connectivity_meshed_region():
     assert np.allclose(connectivity.get_entity_data_by_id(1), [1, 0, 2, 3])
     assert np.allclose(connectivity.get_entity_data(0), [1, 0, 2, 3])
     assert np.allclose(mesh.elements.element_by_id(1).connectivity, [1, 0, 2, 3])
-    new_connectivity_data[0] = 0
-    new_connectivity_data[1] = 1
-    connectivity.data = new_connectivity_data
-    mesh.elements.connectivities_field = connectivity
-
-    nodal_conne = mesh.nodes.nodal_connectivity_field
-    new_connectivity_data = nodal_conne.data
-    new_connectivity_data[0] = 1
-    nodal_conne.data = new_connectivity_data
-    mesh.nodes.nodal_connectivity_field = nodal_conne
-    assert np.allclose(nodal_conne.get_entity_data_by_id(1), [0])
-    assert np.allclose(mesh.nodes.node_by_id(1).nodal_connectivity, [0])
 
 
 def test_create_all_shaped_meshed_region():

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -87,7 +87,7 @@ def test_get_element_meshedregion(simple_bar_model):
     assert node.coordinates == [0.1, 1.6, 0.1]
 
 
-def test_get_coordinates_field_meshedregion(simple_bar_model):
+def test_coordinates_field_meshedregion(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region
     nodescoping = mesh.nodes.scoping
     field_coordinates = mesh.nodes.coordinates_field
@@ -98,6 +98,13 @@ def test_get_coordinates_field_meshedregion(simple_bar_model):
 
     coordinates = mesh.property_field(dpf.core.common.nodal_properties.coordinates)
     assert np.allclose(coordinates.data, field_coordinates.data)
+
+    new_data = field_coordinates.data
+    new_data[0] = [0.0, 0.0, 0.0]
+    field_coordinates.data = new_data
+    mesh.nodes.coordinates_field = field_coordinates
+    field_coordinates = mesh.nodes.coordinates_field
+    assert np.allclose(field_coordinates.data[0], [0.0, 0.0, 0.0])
 
 
 def test_get_element_types_field_meshedregion(simple_bar_model):

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -39,11 +39,20 @@ def test_vtk_grid_from_model(simple_bar_model):
     assert all(grid.celltypes == vtk.VTK_HEXAHEDRON)
 
 
+def test_meshed_region_available_property_fields(simple_bar_model):
+    mesh = simple_bar_model.metadata.meshed_region
+    properties = ['connectivity', 'elprops', 'eltype', 'apdl_element_type', 'section', 'mat']
+    assert mesh.available_property_fields == properties
+
+
 def test_get_element_type_meshedregion(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region
     assert mesh.elements.element_by_index(1).type.value == 11
     assert mesh.elements.element_by_index(1).type == dpf.core.element_types.Hex8
     assert mesh.elements.element_by_index(1).shape == "solid"
+
+    element_types = mesh.property_field(dpf.core.common.elemental_properties.element_type)
+    assert element_types.data[0] == dpf.core.element_types.Hex8
 
 
 def test_get_set_unit_meshedregion(simple_bar_model):
@@ -264,6 +273,11 @@ def test_connectivity_meshed_region():
     nodal_conne = mesh.nodes.nodal_connectivity_field
     assert np.allclose(nodal_conne.get_entity_data_by_id(1), [0])
     assert np.allclose(mesh.nodes.node_by_id(1).nodal_connectivity, [0])
+
+    mesh_connectivity = mesh.property_field(dpf.core.common.elemental_properties.connectivity)
+    assert np.allclose(mesh_connectivity.data, connectivity.data)
+    mesh_nodal = mesh.property_field(dpf.core.common.nodal_properties.nodal_connectivity)
+    assert np.allclose(mesh_nodal.data, nodal_conne.data)
 
 
 @pytest.mark.skipif(not SERVER_VERSION_HIGHER_THAN_3_0,

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -117,6 +117,9 @@ def test_get_materials_field_meshedregion(simple_bar_model):
     assert field_mat.size == elemcoping.size
     assert field_mat.component_count == 1
 
+    materials = mesh.property_field(dpf.core.common.elemental_properties.material)
+    assert np.allclose(materials.data, field_mat.data)
+
 
 def test_get_connectivities_field_meshedregion(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -51,8 +51,8 @@ def test_get_element_type_meshedregion(simple_bar_model):
     assert mesh.elements.element_by_index(1).type == dpf.core.element_types.Hex8
     assert mesh.elements.element_by_index(1).shape == "solid"
 
-    element_types = mesh.property_field(dpf.core.common.elemental_properties.element_type)
-    assert element_types.data[0] == dpf.core.element_types.Hex8
+    types = mesh.property_field(dpf.core.common.elemental_properties.element_type).data
+    assert np.allclose(types, np.full_like(types, 11))
 
 
 def test_get_set_unit_meshedregion(simple_bar_model):

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -258,9 +258,20 @@ def test_connectivity_meshed_region():
     assert np.allclose(connectivity.get_entity_data(0), [0, 1, 2, 3])
     assert np.allclose(mesh.elements.element_by_id(1).connectivity, [0, 1, 2, 3])
 
+    new_connectivity_data = connectivity.data
+    new_connectivity_data[0] = 1
+    new_connectivity_data[1] = 0
+    connectivity.data = new_connectivity_data
+    mesh.elements.connectivities_field = connectivity
+    assert np.allclose(connectivity.get_entity_data_by_id(1), [1, 0, 2, 3])
+    assert np.allclose(connectivity.get_entity_data(0), [1, 0, 2, 3])
+    assert np.allclose(mesh.elements.element_by_id(1).connectivity, [1, 0, 2, 3])
+
+
     nodal_conne = mesh.nodes.nodal_connectivity_field
     assert np.allclose(nodal_conne.get_entity_data_by_id(1), [0])
     assert np.allclose(mesh.nodes.node_by_id(1).nodal_connectivity, [0])
+
 
 
 def test_create_all_shaped_meshed_region():

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -96,6 +96,9 @@ def test_get_coordinates_field_meshedregion(simple_bar_model):
     assert np.allclose(field_coordinates.data[0], [0.1, 2.9, 0.1])
     assert np.allclose(mesh.grid.points, field_coordinates.data)
 
+    coordinates = mesh.property_field(dpf.core.common.nodal_properties.coordinates)
+    assert np.allclose(coordinates.data, field_coordinates.data)
+
 
 def test_get_element_types_field_meshedregion(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -287,6 +287,10 @@ def test_set_connectivity_meshed_region():
     assert np.allclose(connectivity.get_entity_data_by_id(1), [1, 0, 2, 3])
     assert np.allclose(connectivity.get_entity_data(0), [1, 0, 2, 3])
     assert np.allclose(mesh.elements.element_by_id(1).connectivity, [1, 0, 2, 3])
+    new_connectivity_data[0] = 0
+    new_connectivity_data[1] = 1
+    connectivity.data = new_connectivity_data
+    mesh.elements.connectivities_field = connectivity
 
     nodal_conne = mesh.nodes.nodal_connectivity_field
     new_connectivity_data = nodal_conne.data

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -123,7 +123,7 @@ def test_get_element_types_field_meshedregion(simple_bar_model):
     assert field_element_types.component_count == 1
 
 
-def test_get_materials_field_meshedregion(simple_bar_model):
+def test_materials_field_meshedregion(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region
     elemcoping = mesh.elements.scoping
     field_mat = mesh.elements.materials_field
@@ -133,6 +133,13 @@ def test_get_materials_field_meshedregion(simple_bar_model):
 
     materials = mesh.property_field(dpf.core.common.elemental_properties.material)
     assert np.allclose(materials.data, field_mat.data)
+
+    new_data = materials.data
+    new_data[0] = 0
+    materials.data = new_data
+    mesh.elements.materials_field = materials
+    types = mesh.elements.materials_field
+    assert types.data[0] == 0
 
 
 def test_get_connectivities_field_meshedregion(simple_bar_model):

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -265,13 +265,6 @@ def test_connectivity_meshed_region():
     assert np.allclose(nodal_conne.get_entity_data_by_id(1), [0])
     assert np.allclose(mesh.nodes.node_by_id(1).nodal_connectivity, [0])
 
-    new_connectivity_data = nodal_conne.data
-    new_connectivity_data[0] = 1
-    nodal_conne.data = new_connectivity_data
-    mesh.nodes.nodal_connectivity_field = nodal_conne
-    assert np.allclose(nodal_conne.get_entity_data_by_id(1), [0])
-    assert np.allclose(mesh.nodes.node_by_id(1).nodal_connectivity, [0])
-
 
 @pytest.mark.skipif(not SERVER_VERSION_HIGHER_THAN_3_0,
                     reason='Requires server version higher than 3.0')

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -133,6 +133,22 @@ def test_get_connectivities_field_meshedregion(simple_bar_model):
     assert np.allclose(connectivity.data, field_connect.data)
 
 
+@pytest.mark.skipif(not SERVER_VERSION_HIGHER_THAN_3_0,
+                    reason='Requires server version higher than 3.0')
+def test_set_connectivities_field_meshed_region():
+    mesh = test_create_all_shaped_meshed_region()
+
+    connectivity = mesh.elements.connectivities_field
+    new_connectivity_data = connectivity.data
+    new_connectivity_data[0] = 1
+    new_connectivity_data[1] = 0
+    connectivity.data = new_connectivity_data
+    mesh.elements.connectivities_field = connectivity
+    assert np.allclose(connectivity.get_entity_data_by_id(1), [1, 0, 2, 3])
+    assert np.allclose(connectivity.get_entity_data(0), [1, 0, 2, 3])
+    assert np.allclose(mesh.elements.element_by_id(1).connectivity, [1, 0, 2, 3])
+
+
 def test_get_nodes_meshedregion(simple_bar_model):
     mesh = simple_bar_model.metadata.meshed_region
     node = mesh.nodes.node_by_id(1)
@@ -280,26 +296,8 @@ def test_connectivity_meshed_region():
     assert np.allclose(nodal_conne.get_entity_data_by_id(1), [0])
     assert np.allclose(mesh.nodes.node_by_id(1).nodal_connectivity, [0])
 
-    mesh_connectivity = mesh.property_field(dpf.core.common.elemental_properties.connectivity)
-    assert np.allclose(mesh_connectivity.data, connectivity.data)
     mesh_nodal = mesh.property_field(dpf.core.common.nodal_properties.nodal_connectivity)
     assert np.allclose(mesh_nodal.data, nodal_conne.data)
-
-
-@pytest.mark.skipif(not SERVER_VERSION_HIGHER_THAN_3_0,
-                    reason='Requires server version higher than 3.0')
-def test_set_connectivity_meshed_region():
-    mesh = test_create_all_shaped_meshed_region()
-
-    connectivity = mesh.elements.connectivities_field
-    new_connectivity_data = connectivity.data
-    new_connectivity_data[0] = 1
-    new_connectivity_data[1] = 0
-    connectivity.data = new_connectivity_data
-    mesh.elements.connectivities_field = connectivity
-    assert np.allclose(connectivity.get_entity_data_by_id(1), [1, 0, 2, 3])
-    assert np.allclose(connectivity.get_entity_data(0), [1, 0, 2, 3])
-    assert np.allclose(mesh.elements.element_by_id(1).connectivity, [1, 0, 2, 3])
 
 
 def test_create_all_shaped_meshed_region():


### PR DESCRIPTION
Adds setters:
- MeshedRegion.set_named_selection_scoping
- MeshedRegion.set_property_field
- Elements.connectivities_field
- Elements.materials_field
- Elements.element_types_field
- Nodes.coordinates_field

Adds getters:
- MeshedRegion.property_field
- MeshedRegion.available_property_fields