### PR TITLE
Add extra_require "client_binaries" on ansys-dpf-core to isntall ansys-dpf-gatebin

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -19,6 +19,14 @@ To use PyDPF-Core with Ansys 2021 R1, you must install PyDPF-Core with:
 
    pip install ansys-dpf-core<0.3.0
 
+To use PyDPF-Core on a machine where there is no Ansys installation, you must
+install PyDPF-Core with:
+
+.. code::
+
+   pip install ansys-dpf-core[client_binaries]
+
+
 If you are unable to install this module on the host machine due to
 network isolation, download the latest or a specific release wheel at `DPF-Core
 GitHub <https://https://github.com/pyansys/DPF-Core>`_ or from PyPi at

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         "plotting": ["pyvista>=0.32.0", "matplotlib>=3.2"],
+        "client_binaries": ["ansys-dpf-gatebin"],
     },
     url="https://github.com/pyansys/pydpf-core",
     license='MIT',


### PR DESCRIPTION
A new extra_require is added for ansys-dpf-core. Here is the command to install it:
`pip install -e .[client_binaries]`