### PR TITLE
Add wheelhouse generation for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           MODULE: ${{env.MODULE}}
           dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
           install_extras: plotting
-          wheelhouse: false
+          wheelhouse: true
 
       - name: "Prepare Testing Environment"
         uses: pyansys/pydpf-actions/prepare_tests@v2.2


### PR DESCRIPTION
Activate the option for wheelhouse creation when running the normal CI.
Right now this creates a wheelhouse only for Windows 3.8, without plotting dependencies such as pyvista and matplotlib.
Wheelhouse tested in a local venv and working.