### PR TITLE
Add a PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+documentation:
+- docs/source/**/*
+- examples/**/*
+maintenance:
+- .flake8
+- CODE_OF_CONDUCT.md
+- LICENSE
+- README.md
+- codecov.yml
+- ignore_words.txt
+- setup.py
+dependencies:
+- setup.py
+- requirements/*
+CI/CD:
+- docker/**/*
+- .github/**/*
+- .ci/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,85 @@
+name: "Pull Request Labeler"
+on:
+  pull_request:
+    types: [unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+
+    # Label based on modified files
+    - name: Label based on changed files
+      uses: actions/labeler@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        sync-labels: ''
+
+    # Label based on branch name
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'doc') || 
+        startsWith(github.event.pull_request.head.ref, 'docs')
+      with:
+        labels: documentation
+
+    # Label based on branch name
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'example') || 
+        startsWith(github.event.pull_request.head.ref, 'examples')
+      with:
+        labels: examples
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'docker') ||
+        startsWith(github.event.pull_request.head.ref, 'no-ci') ||
+        startsWith(github.event.pull_request.head.ref, 'ci')
+      with:
+        labels: CI/CD
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: startsWith(github.event.pull_request.head.ref, 'maint')
+      with:
+        labels: maintenance
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: startsWith(github.event.pull_request.head.ref, 'feat')
+      with:
+        labels: |
+          enhancement
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'fix') ||
+        startsWith(github.event.pull_request.head.ref, 'patch')
+      with:
+        labels: bug
+
+  commenter:
+    runs-on: ubuntu-latest
+    needs: labeler
+    steps:
+    - name: Suggest to add labels
+      uses: peter-evans/create-or-update-comment@v2
+      # Execute only when no labels have been applied to the pull request
+      if: toJSON(github.event.pull_request.labels.*.name) == '[]'
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Please add one of the following labels to add this contribution to the Release Notes :point_down:
+          - [bug](https://github.com/pyansys/pydpf-core/pulls?q=label%3Abug+)
+          - [enhancement](https://github.com/pyansys/pydpf-core/pulls?q=label%3Aenhancement+)
+          - [documentation](https://github.com/pyansys/pydpf-core/pulls?q=label%3Adocumentation+)
+          - [examples](https://github.com/pyansys/pydpf-core/pulls?q=label%3Aexamples+)
+          - [maintenance](https://github.com/pyansys/pydpf-core/pulls?q=label%3Amaintenance+)
+          - [CI/CD](https://github.com/pyansys/pydpf-core/pulls?q=label%3Aci%2Fcd+)


### PR DESCRIPTION
Partially resolves #218 

Adding a label.yml workflow and a labeler.yml (used by actions/labeler) means that PRs will now get automatic labels based on the content they modify (thanks to actions/labeler) and/or the branch name.
This can be changed manually by the creator of the PR, but it is useful for classifying PRs better and more easily when drafting a Release.