### PR TITLE
add copybutton

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,16 +44,17 @@ release = __version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx_gallery.gen_gallery",
-    "sphinx.ext.todo",
-    "sphinx.ext.napoleon",
-    "pydata_sphinx_theme",
-    "sphinx_design",
-    "nbsphinx",
-    "sphinx.ext.graphviz",
     "enum_tools.autoenum",
-    "sphinx.ext.intersphinx"
+    "nbsphinx",
+    "pydata_sphinx_theme",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.graphviz",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx_gallery.gen_gallery",
 ]
 
 # Intersphinx mapping


### PR DESCRIPTION
Documentation is missing [Sphinx-copybutton](https://sphinx-copybutton.readthedocs.io/). This PR simply adds it to the extensions as well as sorting them.
