### PR TITLE
The branch name given must changed to a string

### DIFF
--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Clone PyDPF-Post"
         run: |
           $BranchName = ${{ inputs.PyDPF-Post_branch }}
-          git clone --branch $BranchName --single-branch https://${{secrets.pydpf-post-TOKEN}}@github.com/pyansys/pydpf-post
+          git clone --branch "$BranchName" --single-branch https://${{secrets.pydpf-post-TOKEN}}@github.com/pyansys/pydpf-post
         shell: pwsh
 
       - name: "Install PyDPF-Post"


### PR DESCRIPTION
This makes the manually triggered testing workflow for PyDPF-Post work.