### PR TITLE
Remove restriction on protobuf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from io import open as io_open
 
 from setuptools import setup
 
-install_requires = ["packaging", "psutil", "tqdm", "numpy", "ansys-dpf-gate", "protobuf<=3.20.1"]
+install_requires = ["packaging", "psutil", "tqdm", "numpy", "ansys-dpf-gate"]
 
 # Get version from version info
 filepath = os.path.dirname(__file__)


### PR DESCRIPTION
Since the release of ansys-dpf-gate, the protos have been generated and are compatible with higher versions of protobuf.