### PR TITLE
Resolve documentation not generating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,11 +223,22 @@ jobs:
         with:
           python-version: 3.8
 
-#      - name: "Install OS packages"
-#        shell: bash
-#        run: |
-#          sudo apt update
-#          sudo apt install pandoc texlive-latex-extra latexmk
+      - name: "Install OS packages - Linux"
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install pandoc texlive-latex-extra latexmk
+
+      - name: "Install OS packages - Windows"
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install pandoc 
+
+#          choco install miktex
+#          texlive-latex-extra
+#          choco latexmk
 
       - name: "Install DPF"
         uses: pyansys/pydpf-actions/install-dpf-server@v2.2.dev1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,28 +213,40 @@ jobs:
 
   docs:
     name: "Documentation"
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Python
+      - name: "Setup Python"
         uses: actions/setup-python@v4.2.0
         with:
           python-version: 3.8
 
-      - name: "Build Package"
-        id: build-package
-        uses: pyansys/pydpf-actions/build_package@v2.2.dev1
+      - name: "Install OS packages"
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install pandoc texlive-latex-extra latexmk
+
+      - name: "Install DPF"
+        uses: pyansys/pydpf-actions/install-dpf-server@v2.2.dev1
         with:
-          python-version: ${{ matrix.python-version }}
-          ANSYS_VERSION: ${{env.ANSYS_VERSION}}
-          PACKAGE_NAME: ${{env.PACKAGE_NAME}}
-          MODULE: ${{env.MODULE}}
-          dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
-          install_extras: plotting
-          wheelhouse: false
-          extra-pip-args: ${{ env.extra }}
+          dpf-standalone-TOKEN: ${{secrets.dpf-standalone-TOKEN}}
+          ANSYS_VERSION : ${{env.ANSYS_VERSION}}
+
+      - name: "Install local package"
+        uses: pyansys/pydpf-actions/install-package@v2.2.dev1
+
+      - name: "Install extras"
+        shell: bash
+        run: |
+          pip install .[plotting]
+
+      - name: "Test import"
+        shell: bash
+        working-directory: tests
+        run: python -c "from ansys.dpf import ${{env.MODULE}}"
 
       - name: "Setup headless display"
         uses: pyvista/setup-headless-display-action@v1
@@ -242,38 +254,38 @@ jobs:
       - name: "Setup Graphviz"
         uses: ts-graphviz/setup-graphviz@v1
 
-      - name: "Install documentation packages for Python"
+      - name: "Install documentation requirements"
+        shell: bash
         run: |
           pip install -r requirements/requirements_docs.txt
 
-      - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1
-
-      - name: "Build HTML Documentation"
-        shell: cmd
-        run: |
-          cd .ci
-          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
-        timeout-minutes: 20
-
-      - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1
-        if: always()
-
-      - name: "Retrieve package version"
+      - name: "Debug mode"
         shell: bash
         run: |
-          echo "::set-output name=VERSION::$(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")"
-          echo "${{env.PACKAGE_NAME}} version is: $(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")"
-        id: version
-        if: always()
+          echo "DEBUG_BUILD=&>log_sphinx.txt" >> $GITHUB_ENV
+          echo "DEBUG_HTML=&>log_html.txt" >> $GITHUB_ENV
+          echo "DEBUG_PDF=&>log_pdf.txt" >> $GITHUB_ENV
 
-      - name: "Upload Documentation Build log"
-        uses: actions/upload-artifact@v3
-        with:
-          name: doc-${{env.PACKAGE_NAME}}-log
-          path: docs/*.txt
-        if: always()
+      - name: "Build sphinx doc"
+        shell: bash
+        run: |
+          export SPHINX_APIDOC_OPTIONS=inherited-members
+          sphinx-apidoc -o docs/source/api ansys -f -v -v --implicit-namespaces --separate --no-headings $DEBUG_BUILD
+
+      - name: "Build HTML Documentation"
+        shell: bash
+        working-directory: docs
+        run: |
+          export TEMP=${{ runner.temp }}
+          make clean
+          echo "Making html doc..."
+          make html $DEBUG_HTML
+
+#      - name: "Upload Documentation Build log"
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: doc-${{env.PACKAGE_NAME}}-log
+#          path: docs/*.txt
 
       - name: "Zip HTML Documentation"
         uses: vimtor/action-zip@v1
@@ -286,6 +298,10 @@ jobs:
         with:
           name: HTML-doc-${{env.PACKAGE_NAME}}
           path: HTML-doc-${{env.PACKAGE_NAME}}.zip
+
+      - name: "Kill all servers"
+        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1
+        if: always()
 
   run_examples:
     name: "Run Examples with/without bin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,11 @@ jobs:
         working-directory: docs
         run: |
           export TEMP=${{ runner.temp }}
+          echo $SPHINXOPTS
+          export SPHINXOPTS=-v -v
           make clean
           echo "Making html doc..."
-          make html -v -v
+          make html
 
 #      - name: "Upload Documentation Build log"
 #        uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: "Install DPF"
         uses: pyansys/pydpf-actions/install-dpf-server@v2.2.dev1
         with:
-          dpf-standalone-TOKEN: ${{secrets.dpf-standalone-TOKEN}}
+          dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
           ANSYS_VERSION : ${{env.ANSYS_VERSION}}
 
       - name: "Install local package"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,11 @@ jobs:
         shell: bash
         run: |
           export SPHINX_APIDOC_OPTIONS=inherited-members
-          sphinx-apidoc -o docs/source/api ansys -f --implicit-namespaces --separate --no-headings
+          sphinx-apidoc -o docs/source/api ansys ansys/dpf/core/log.py ansys/dpf/core/help.py \
+          ansys/dpf/core/mapping_types.py ansys/dpf/core/ipconfig.py ansys/dpf/core/field_base.py \
+          ansys/dpf/core/cache.py ansys/dpf/core/misc.py ansys/dpf/core/check_version.py \
+          ansys/dpf/core/operators/build.py ansys/dpf/core/operators/specification.py \
+          ansys/dpf/core/vtk_helper.py -f --implicit-namespaces --separate  --no-headings
 
       - name: "Build HTML Documentation"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
         run: |
           export TEMP=${{ runner.temp }}
           echo $SPHINXOPTS
-          export SPHINXOPTS=-v -v
+          export SPHINXOPTS="-v"
           make clean
           echo "Making html doc..."
           make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,18 +259,11 @@ jobs:
         run: |
           pip install -r requirements/requirements_docs.txt
 
-      - name: "Debug mode"
-        shell: bash
-        run: |
-          echo "DEBUG_BUILD=&>log_sphinx.txt" >> $GITHUB_ENV
-          echo "DEBUG_HTML=&>log_html.txt" >> $GITHUB_ENV
-          echo "DEBUG_PDF=&>log_pdf.txt" >> $GITHUB_ENV
-
       - name: "Build sphinx doc"
         shell: bash
         run: |
           export SPHINX_APIDOC_OPTIONS=inherited-members
-          sphinx-apidoc -o docs/source/api ansys -f -v -v --implicit-namespaces --separate --no-headings $DEBUG_BUILD
+          sphinx-apidoc -o docs/source/api ansys -f --implicit-namespaces --separate --no-headings
 
       - name: "Build HTML Documentation"
         shell: bash
@@ -279,7 +272,7 @@ jobs:
           export TEMP=${{ runner.temp }}
           make clean
           echo "Making html doc..."
-          make html $DEBUG_HTML
+          make html -v -v
 
 #      - name: "Upload Documentation Build log"
 #        uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          choco install pandoc 
+          choco install pandoc --no-progress
 
 #          choco install miktex
 #          texlive-latex-extra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
 
   docs:
     name: "Documentation"
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -223,11 +223,11 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: "Install OS packages"
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install pandoc texlive-latex-extra latexmk
+#      - name: "Install OS packages"
+#        shell: bash
+#        run: |
+#          sudo apt update
+#          sudo apt install pandoc texlive-latex-extra latexmk
 
       - name: "Install DPF"
         uses: pyansys/pydpf-actions/install-dpf-server@v2.2.dev1

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,40 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?= -j auto
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+
+# customized clean
+clean:
+	rm -rf $(BUILDDIR)/*
+	rm -rf source/examples/
+	find . -type d -name "_autosummary" -exec rm -rf {} +
+
+# customized to build the pdf rather than using latexpdf due to various issues
+# with our docs like GIFs being written as PNG.
+pdf:
+	@$(SPHINXBUILD) -M latex "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	cd build/latex && latexmk -r latexmkrc -pdf *.tex -interaction=nonstopmode || true
+	(test -f build/latex/*.pdf && echo pdf exists) || exit 1
+
+# customized clean due to examples gallery
+clean-except-examples:
+	rm -rf $(BUILDDIR)/*
+	rm -rf images/auto-generated
+	find . -type d -name "_autosummary" -exec rm -rf {} +

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -11,6 +11,7 @@ set SOURCEDIR=source
 set BUILDDIR=build
 
 if "%1" == "" goto help
+if "%1" == "clean" goto clean
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -26,6 +27,11 @@ if errorlevel 9009 (
 )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:clean
+rmdir /s /q %BUILDDIR% > /NUL 2>&1
+for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
 goto end
 
 :help

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,8 @@ if not os.path.exists(pyvista.FIGURE_PATH):
 
 pyvista.BUILDING_GALLERY = True
 
+pyvista.global_theme.lighting = False
+
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/examples/06-distributed-post/README.txt
+++ b/examples/06-distributed-post/README.txt
@@ -1,6 +1,6 @@
 .. _distributed_post:
 
 Examples for postprocessing on distributed processes
-================================================_===
+====================================================
 These examples show how to create workflows on different processes (possibly on
 different machines) and connect them.


### PR DESCRIPTION

The Documentation check passes but the documentation artifact is actually empty (easily verified with its small size of 48 kB, should be more than 100MB).
The last known Documentation generation job to work was [here](https://github.com/pyansys/pydpf-core/actions/runs/2901998839) on August 22.
Was rerun to check for unseen change in a dependency, it still passed.

Seems to have started with bump of Graphviz to 0.20.1 [here](https://github.com/pyansys/pydpf-core/actions/runs/2754279313). Cannot find an occurrence before that.

Two problems here:

the documentation check did not see something was wrong with the doc (artifact too small / step too short)
no error was raised although something went obviously wrong