### PR TITLE
Mirror fix to the TFS pipeline

### DIFF
--- a/ansys/dpf/core/settings.py
+++ b/ansys/dpf/core/settings.py
@@ -44,24 +44,7 @@ def bypass_pv_opengl_osmesa_crash():
     if module_exists("pyvista"):
         import pyvista as pv
 
-        def get_lighting():
-            """Get lighting configuration.
-
-            Disable lighting when using OSMesa on Windows. See:
-            https://github.com/pyvista/pyvista/issues/3185
-
-            """
-            pl = pv.Plotter(notebook=False, off_screen=True)
-            pl.add_mesh(pv.Sphere())
-            pl.show(auto_close=False)
-            gpu_info = pl.ren_win.ReportCapabilities()
-            pl.close()
-
-            regex = re.compile("OpenGL version string:(.+)\n")
-            version = regex.findall(gpu_info)[0]
-            return not(os.name == 'nt' and 'Mesa' in version)
-
-        pv.global_theme.lighting = get_lighting()
+        pv.global_theme.lighting = False
 
 
 def disable_interpreter_properties_evaluation() -> bool:

--- a/ansys/dpf/core/settings.py
+++ b/ansys/dpf/core/settings.py
@@ -4,8 +4,6 @@ settings
 ========
 Customize the behavior of the module.
 """
-import os
-import re
 
 from ansys.dpf.core.misc import module_exists
 from ansys.dpf.core import misc


### PR DESCRIPTION
Always set pv.global_theme.lighting to False, without running a pyvista plotter first.
Mirroring a fix made on the TFS side.

Context:
Depending on the runner (on TFS it was the Linux one), the pyvista lighting could make opengl crash.
The fix found first and working on GitHub was to set the lighting to False when using a specific version of Mesa OpenGL.
A pyvista plotter was first run to find out what OpenGL version was installed. 
This crashed the pytest session on the Linux runner for TFS.

Setting this to False always to fix both problems and any other potential configuration, until the fix on the pyvista side is deployed. 