### PR TITLE
Fix Ansys R212 compatibility issue.

### DIFF
--- a/ansys/dpf/core/support.py
+++ b/ansys/dpf/core/support.py
@@ -46,6 +46,9 @@ class Support:
         # step 1: get server
         self._server = server_module.get_or_create_server(server)
 
+        if not self._server.meet_version("3.0"):
+            return
+
         # step 2: get api
         self._support_api = self._server.get_api_for_type(
             capi=support_capi.SupportCAPI,

--- a/ansys/dpf/core/support.py
+++ b/ansys/dpf/core/support.py
@@ -46,7 +46,7 @@ class Support:
         # step 1: get server
         self._server = server_module.get_or_create_server(server)
 
-        if not self._server.meet_version("3.0"):
+        if not self._server.meet_version("3.0"):  # pragma: no cover
             return
 
         # step 2: get api


### PR DESCRIPTION
Solves #473 
Fix an import error (due to the latest development of Generic Supports) when using ansys-grpc-dpf 0.3.0 with Ansys 212 and initializing a TimeFreqSupport.