### PR TITLE
Add necessary check after documentation build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,18 +256,26 @@ jobs:
           build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
         timeout-minutes: 20
 
-      - name: "Check for successful generation"
-        id: check_files
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "./docs/build/html/index.html"
+      - name: "Check for success"
+        shell: bash
+        working-directory: ..\docs\
+        run: |
+          s="build succeeded"
+          e=$(grep -q "$s" log.txt | tail -n 5)
+          exit "$e"
 
-      - name: "Fail the job if no index.html was found"
-        uses: actions/github-script@v6
-        if: steps.check_files.outputs.files_exists == 'false'
-        with:
-          script: |
-              core.setFailed('Documentation generation failed, please check previous step.')
+#      - name: "Check for successful generation"
+#        id: check_files
+#        uses: andstor/file-existence-action@v1
+#        with:
+#          files: "./docs/build/html/index.html"
+#
+#      - name: "Fail the job if no index.html was found"
+#        uses: actions/github-script@v6
+#        if: steps.check_files.outputs.files_exists == 'false'
+#        with:
+#          script: |
+#              core.setFailed('Documentation generation failed, please check previous step.')
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1
@@ -294,15 +302,15 @@ jobs:
           files: docs/build/html
           dest: HTML-doc-${{env.PACKAGE_NAME}}.zip
 
-      - name: "Test zip size"
-        shell: bash
-        run: |
-          s=$(du -k "HTML-doc-${{env.PACKAGE_NAME}}.zip" | cut -f1)
-          if $s lt 40000000 
-          then
-            echo ERROR: Documentation too small! 1>&2
-            exit 1
-          fi
+#      - name: "Test zip size"
+#        shell: bash
+#        run: |
+#          s=$(du -k "HTML-doc-${{env.PACKAGE_NAME}}.zip" | cut -f1)
+#          if $s lt 40000000
+#          then
+#            echo ERROR: Documentation too small! 1>&2
+#            exit 1
+#          fi
 
       - name: "Upload HTML Documentation"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         run: |
           cd .ci
           build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
-        timeout-minutes: 20
+        timeout-minutes: 25
 
       - name: "Check for success"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
         if: steps.check_files.outputs.files_exists == 'false'
         with:
           script: |
-              core.setFailed('Documentation generation failed, please check previous step.')
+              core.setFailed('Could not find index.html!')
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,8 @@ jobs:
         working-directory: docs
         run: |
           s="build succeeded"
-          e=$(grep -q "$s" log.txt | tail -n 5)
+          e=$(tail -n 5 log.txt | grep -q "$s")
+          echo "$e"
           exit "$e"
 
 #      - name: "Check for successful generation"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,16 @@ jobs:
           files: docs/build/html
           dest: HTML-doc-${{env.PACKAGE_NAME}}.zip
 
+      - name: "Test zip size"
+        shell: bash
+        run: |
+          s=$(du -k "HTML-doc-${{env.PACKAGE_NAME}}.zip" | cut -f1)
+          if $s lt 40000000 
+          then
+            echo ERROR: Documentation too small! 1>&2
+            exit 1
+          fi
+
       - name: "Upload HTML Documentation"
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
         id: check_files
         uses: andstor/file-existence-action@v1
         with:
-          files: "./docs/build.html/index.html"
+          files: "./docs/build/html/index.html"
 
       - name: "Fail the job if no index.html was found"
         uses: actions/github-script@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,25 +266,12 @@ jobs:
             echo "Build succeeded!"
             exit 0;;
           1)
-            echo "Build failed!"
+            echo "Documentation generation failed, please check previous step!"
             exit 1;;
           *)
-            echo "An error occurred!"
+            echo "An error occurred while checking success of the previous step!"
             exit 1;;
           esac
-
-#      - name: "Check for successful generation"
-#        id: check_files
-#        uses: andstor/file-existence-action@v1
-#        with:
-#          files: "./docs/build/html/index.html"
-#
-#      - name: "Fail the job if no index.html was found"
-#        uses: actions/github-script@v6
-#        if: steps.check_files.outputs.files_exists == 'false'
-#        with:
-#          script: |
-#              core.setFailed('Documentation generation failed, please check previous step.')
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1
@@ -310,16 +297,6 @@ jobs:
         with:
           files: docs/build/html
           dest: HTML-doc-${{env.PACKAGE_NAME}}.zip
-
-#      - name: "Test zip size"
-#        shell: bash
-#        run: |
-#          s=$(du -k "HTML-doc-${{env.PACKAGE_NAME}}.zip" | cut -f1)
-#          if $s lt 40000000
-#          then
-#            echo ERROR: Documentation too small! 1>&2
-#            exit 1
-#          fi
 
       - name: "Upload HTML Documentation"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,9 +261,13 @@ jobs:
         working-directory: docs
         run: |
           s="build succeeded"
-          e=$(tail -n 5 log.txt | grep -q "$s")
-          echo "$e"
-
+          if tail -n 5 log.txt | grep -q "$s"
+          then
+            echo "Found"
+            exit 0
+          else
+            exit 1
+          fi
 #          exit "$e"
 
 #      - name: "Check for successful generation"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,16 +294,6 @@ jobs:
           files: docs/build/html
           dest: HTML-doc-${{env.PACKAGE_NAME}}.zip
 
-      - name: "Test zip size"
-        shell: bash
-        run: |
-          s=$(du -k "HTML-doc-${{env.PACKAGE_NAME}}.zip" | cut -f1)
-          if $s lt 40000000 
-          then
-            echo ERROR: Documentation too small! 1>&2
-            exit 1
-          fi
-
       - name: "Upload HTML Documentation"
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: "Check for success"
         shell: bash
-        working-directory: ..\docs\
+        working-directory: docs
         run: |
           s="build succeeded"
           e=$(grep -q "$s" log.txt | tail -n 5)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,19 @@ jobs:
           build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
         timeout-minutes: 20
 
+      - name: "Check for successful generation"
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "./docs/build.html/index.html"
+
+      - name: "Fail the job if no index.html was found"
+        uses: actions/github-script@v6
+        if: steps.check_files.outputs.files_exists == 'false'
+        with:
+          script: |
+              core.setFailed('Could not find index.html!')
+
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,8 @@ jobs:
           s="build succeeded"
           e=$(tail -n 5 log.txt | grep -q "$s")
           echo "$e"
-          exit "$e"
+
+#          exit "$e"
 
 #      - name: "Check for successful generation"
 #        id: check_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,8 +253,9 @@ jobs:
         shell: cmd
         run: |
           cd .ci
-          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
         timeout-minutes: 20
+
+#          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
 
       - name: "Check for successful generation"
         id: check_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         run: |
           cd .ci
           build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
-        timeout-minutes: 25
+        timeout-minutes: 40
 
       - name: "Check for success"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
         if: steps.check_files.outputs.files_exists == 'false'
         with:
           script: |
-              core.setFailed('Could not find index.html!')
+              core.setFailed('Documentation generation failed, please check previous step.')
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,9 +253,8 @@ jobs:
         shell: cmd
         run: |
           cd .ci
+          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
         timeout-minutes: 20
-
-#          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
 
       - name: "Check for successful generation"
         id: check_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,15 +260,17 @@ jobs:
         shell: bash
         working-directory: docs
         run: |
-          s="build succeeded"
-          if tail -n 5 log.txt | grep -q "$s"
-          then
-            echo "Found"
-            exit 0
-          else
-            exit 1
-          fi
-#          exit "$e"
+          case `tail -n 5 log.txt | grep -F "build succeeded" >/dev/null; echo $?` in
+            0)
+              echo "Build succeeded!"
+              exit 0
+            1)
+              echo "Build failed!"
+              exit 1
+            *)
+              echo "An error occurred!"
+              exit 1
+          esac
 
 #      - name: "Check for successful generation"
 #        id: check_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         run: |
           cd .ci
           build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
-        timeout-minutes: 40
+        timeout-minutes: 20
 
       - name: "Check for success"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,15 +261,15 @@ jobs:
         working-directory: docs
         run: |
           case `tail -n 5 log.txt | grep -F "build succeeded" >/dev/null; echo $?` in
-            0)
-              echo "Build succeeded!"
-              exit 0
-            1)
-              echo "Build failed!"
-              exit 1
-            *)
-              echo "An error occurred!"
-              exit 1
+          0)
+            echo "Build succeeded!"
+            exit 0;;
+          1)
+            echo "Build failed!"
+            exit 1;;
+          *)
+            echo "An error occurred!"
+            exit 1;;
           esac
 
 #      - name: "Check for successful generation"

--- a/ansys/dpf/core/streams_container.py
+++ b/ansys/dpf/core/streams_container.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 StreamsContainer
-===============
+================
 Contains classes associated with the DPF StreamsContainer.
 """
 import warnings

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -53,4 +53,4 @@ If you want to edit and potentially contribute to PyDPF-Core,
 clone the repository and install it using ``pip`` with the ``-e``
 development flag:
 
-.. include:: ../pydpf-post_clone_install.rst
+.. include:: ../pydpf-core_clone_install.rst

--- a/examples/03-advanced/02-volume_averaged_stress.py
+++ b/examples/03-advanced/02-volume_averaged_stress.py
@@ -88,7 +88,7 @@ with connectivity_field.as_local_field() as connectivity:
 
 ###############################################################################
 # Create workflow
-# ~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~
 # For each list of elements surrounding nodes:
 #
 # - Compute equivalent stress averaged on elements.
@@ -132,13 +132,13 @@ divide.run()
 
 ###############################################################################
 # Plot equivalent elemental stress and volume averaged elemental equivalent stress
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 mesh.plot(values_to_sum_field)
 mesh.plot(divide.outputs.field())
 
 ###############################################################################
 # Use the operator instead
-# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~
 # An operator with the same algorithm has been implemented
 s_fc = s.outputs.fields_container()
 single_field_vol_fc = dpf.fields_container_factory.over_time_freq_fields_container(

--- a/examples/06-distributed-post/02-distributed-msup_expansion.py
+++ b/examples/06-distributed-post/02-distributed-msup_expansion.py
@@ -2,7 +2,7 @@
 .. _ref_distributed_msup:
 
 Distributed mode superposition (MSUP)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This example shows how to read and expand distributed files
 on distributed processes. The modal basis (two distributed files) is read
 on two remote servers. The modal response is then read and expanded on a

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -1,5 +1,5 @@
 pypandoc==1.8.1
-sphinx==0.5.1
+sphinx==5.1.0
 pyvista==0.36.1
 ansys_sphinx_theme==0.5.2
 nbsphinx==0.8.9

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -1,4 +1,5 @@
 pypandoc==1.8.1
+sphinx==0.5.1
 pyvista==0.36.1
 ansys_sphinx_theme==0.5.2
 nbsphinx==0.8.9

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -1,5 +1,5 @@
 pypandoc==1.8.1
-sphinx==5.1.0
+sphinx==5.1.1
 pyvista==0.36.1
 ansys_sphinx_theme==0.5.2
 nbsphinx==0.8.9


### PR DESCRIPTION
The documentation generation job does not fail as long as "something" is in docs/build to be zipped, which is a problem when the documentation build script does not raise a failure although the generation is not complete.
Adding a step checking that index.html exists.
Could also add a criterion on the size of the folder. 