### PR TITLE
force sphinx to 5.1.1

### DIFF
--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -1,4 +1,5 @@
 pypandoc==1.8.1
+sphinx==0.5.1
 pyvista==0.36.1
 ansys_sphinx_theme==0.5.2
 imageio-ffmpeg==0.4.7

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -1,5 +1,5 @@
 pypandoc==1.8.1
-sphinx==5.1.0
+sphinx==5.1.1
 pyvista==0.36.1
 ansys_sphinx_theme==0.5.2
 imageio-ffmpeg==0.4.7

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -1,5 +1,5 @@
 pypandoc==1.8.1
-sphinx==0.5.1
+sphinx==5.1.0
 pyvista==0.36.1
 ansys_sphinx_theme==0.5.2
 imageio-ffmpeg==0.4.7


### PR DESCRIPTION
Sphinx 5.2.0 got out this weekend and seems to break doc generation. Several issues pending on the Sphinx Github.

Edit: Sphinx 5.2.1 got out in the night of 09/25, yet our latest pipelines seem to still break.