### PR TITLE
Fix the compatibility table for R222

### DIFF
--- a/docs/source/getting_started/compatibility.rst
+++ b/docs/source/getting_started/compatibility.rst
@@ -40,9 +40,9 @@ should also be synchronized with the server version.
      - 0.6.0 and later
      - 0.6.0 and later
    * - 4.0 (Ansys 2022 R2)
-     - 0.1.1
-     - 0.1.1
-     - 0.5.1
+     - 0.1.*
+     - 0.1.*
+     - 0.5.*
      - 0.5.0 and later
    * - 3.0 (Ansys 2022 R1)
      - None


### PR DESCRIPTION
Include pygate 0.1.2 in the compatibility for R222, as well as grpc-dpf 0.5.2, by writing 0.1.* and 0.5.* as compatible versions.