### PR TITLE
Bump to 0.6.1.dev0

### DIFF
--- a/ansys/dpf/core/_version.py
+++ b/ansys/dpf/core/_version.py
@@ -1,6 +1,6 @@
 """Version for ansys-dpf-core"""
 # major, minor, patch
-version_info = 0, 6, '1dev0'
+version_info = 0, 6, 1, 'dev0'
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Use a dot between patch number and dev0 to be coherent with PyPI notation.