### PR TITLE
Fix animator and reduce testing time

### DIFF
--- a/ansys/dpf/core/animator.py
+++ b/ansys/dpf/core/animator.py
@@ -250,7 +250,7 @@ def scale_factor_to_fc(scale_factor, fc):
         return field
 
     scale_type = type(scale_factor)
-    n_sets = fc.time_freq_support.n_sets
+    n_sets = len(fc)
     if scale_type == core.field.Field:
         raise NotImplementedError("Scaling by a Field is not yet implemented.")
         # # Turn the Field into a fields_container

--- a/tests/test_animator.py
+++ b/tests/test_animator.py
@@ -29,7 +29,8 @@ def displacement_fields():
     model = dpf.Model(examples.msup_transient)
     mesh_scoping = dpf.mesh_scoping_factory.nodal_scoping(
         model.metadata.meshed_region.nodes.scoping)
-    time_scoping = dpf.time_freq_scoping_factory.scoping_on_all_time_freqs(model)
+    # time_scoping = dpf.time_freq_scoping_factory.scoping_on_all_time_freqs(model)
+    time_scoping = [1, 2]
     displacement_op = model.results.displacement
     displacement_op = displacement_op.on_time_scoping(time_scoping)
     displacement_op = displacement_op.on_mesh_scoping(mesh_scoping)
@@ -70,9 +71,9 @@ def test_animator_animate(remove_gifs, displacement_fields):
     wf.set_output_name("to_render", extract_field_op.outputs.field)
 
     an = Animator(wf)
-    an.animate(loop_over=loop_over_field, save_as=gif_name)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    an.animate(loop_over=loop_over_field)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_raise_wrong_scale_factor(remove_gifs, displacement_fields):
@@ -94,15 +95,15 @@ def test_animator_animate_raise_wrong_scale_factor(remove_gifs, displacement_fie
 
 
 def test_animator_animate_fields_container(remove_gifs, displacement_fields):
-    displacement_fields.animate(save_as=gif_name)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate()
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_deform_by_false(remove_gifs, displacement_fields):
-    displacement_fields.animate(save_as=gif_name, deform_by=False)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate(deform_by=False)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_eqv_partial_scoping(remove_gifs):
@@ -118,25 +119,25 @@ def test_animator_animate_fields_container_eqv_partial_scoping(remove_gifs):
     displacement_result = model.results.displacement.on_time_scoping(time_scoping)
 
     stress_fields = stress_result.on_location(dpf.common.locations.nodal).eval()
-    stress_fields.animate(save_as=gif_name, deform_by=displacement_result, scale_factor=20.,
+    stress_fields.animate(deform_by=displacement_result, scale_factor=20.,
                           framerate=1.)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 400000
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 400000
 
 
 def test_animator_animate_fields_container_one_component(remove_gifs, displacement_fields):
-    displacement_fields.select_component(0).animate(save_as=gif_name)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.select_component(0).animate()
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_deform_by_convert_unit(remove_gifs, displacement_fields):
     new_displacement_fields = displacement_fields.deep_copy()
     dpf.operators.math.unit_convert_fc(
         fields_container=new_displacement_fields, unit_name="mm")
-    displacement_fields.animate(save_as=gif_name, deform_by=new_displacement_fields)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate(deform_by=new_displacement_fields)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_scale_factor_raise(displacement_fields):
@@ -149,43 +150,43 @@ def test_animator_animate_fields_container_deform_by_result(remove_gifs):
     model = dpf.Model(examples.msup_transient)
     displacement_result = model.results.displacement.on_all_time_freqs
     displacement_fields = displacement_result.eval()
-    displacement_fields.animate(save_as=gif_name, deform_by=displacement_result)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate(deform_by=displacement_result)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_deform_by_operator(remove_gifs):
     model = dpf.Model(examples.msup_transient)
     displacement_op = model.results.displacement.on_all_time_freqs()
     displacement_fields = displacement_op.eval()
-    displacement_fields.animate(save_as=gif_name, deform_by=displacement_op)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate(deform_by=displacement_op)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_scale_factor_int(remove_gifs, displacement_fields):
-    displacement_fields.animate(save_as=gif_name, scale_factor=2)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate(scale_factor=2)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_scale_factor_float(remove_gifs, displacement_fields):
-    displacement_fields.animate(save_as=gif_name, scale_factor=2.0)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate(scale_factor=2.0)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_scale_factor_zero(remove_gifs, displacement_fields):
-    displacement_fields.animate(save_as=gif_name, scale_factor=0.0)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate(scale_factor=0.0)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_scale_factor_list(remove_gifs, displacement_fields):
     scale_factor_list = [2.0]*len(displacement_fields)
-    displacement_fields.animate(save_as=gif_name, scale_factor=scale_factor_list)
-    assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    displacement_fields.animate(scale_factor=scale_factor_list)
+    # assert os.path.isfile(gif_name)
+    # assert os.path.getsize(gif_name) > 600000
 
 
 def test_animator_animate_fields_container_scale_factor_raise_list_len(remove_gifs,
@@ -227,4 +228,4 @@ def test_animator_animate_fields_container_cpos(remove_gifs, displacement_fields
                                 off_screen=True,
                                 show_axes=True)
     assert os.path.isfile(gif_name)
-    assert os.path.getsize(gif_name) > 600000
+    assert os.path.getsize(gif_name) > 6000


### PR DESCRIPTION
Reduces test_animator.py total time from 50s to 10s by removing GIF generation at every test except one, and by reducing the number of timesteps in the FieldsContainer to animate to 2 instead of the whole 20 initially present.