### PR TITLE
Update deprecated "set-output" command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
       - name: "Retrieve package version"
         shell: bash
         run: |
-          echo "::set-output name=VERSION::$(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")"
+          echo "VERSION=$(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")" >> $GITHUB_OUTPUT
           echo "${{env.PACKAGE_NAME}} version is: $(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")"
         id: version
         if: always()

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: "Get the version"
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: "Download Release Asset - HTML"
         uses: dsaltares/fetch-gh-release-asset@1.0.0


### PR DESCRIPTION
[Reference](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)