### PR TITLE
MAINT: improve examples

### DIFF
--- a/examples/00-basic/00-basic_example.py
+++ b/examples/00-basic/00-basic_example.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_basic_example:
 
@@ -6,11 +7,11 @@ Basic DPF-Core usage
 This example shows how to open a result file and do some
 basic postprocessing.
 
-If you have Ansys 2021 R1 installed, starting DPF is quite easy
+If you have Ansys 2021 R1 or higher installed, starting DPF is quite easy
 as DPF-Core takes care of launching all the services that
 are required for postprocessing Ansys files.
 
-First, import the DPF-Core module as ``dpf_core`` and import the
+First, import the DPF-Core module as ``dpf`` and import the
 included examples file.
 
 
@@ -21,8 +22,8 @@ from ansys.dpf.core import examples
 
 ###############################################################################
 # Next, open an example and print out the ``model`` object. The
-# ``Model`` class helps to organize access methods for the result by
-# keeping track of the operators and data sources used by the result
+# :class:`Model <ansys.dpf.core.model.Model>` class helps to organize access methods
+# for the result by keeping track of the operators and data sources used by the result
 # file.
 #
 # Printing the model displays:
@@ -35,7 +36,7 @@ from ansys.dpf.core import examples
 # Also, note that the first time you create a DPF object, Python
 # automatically attempts to start the server in the background. If you
 # want to connect to an existing server (either local or remote), use
-# :func:`dpf.connect_to_server`.
+# :func:`ansys.dpf.core.connect_to_server`.
 
 model = dpf.Model(examples.find_simple_bar())
 print(model)

--- a/examples/00-basic/01-basic_operators.py
+++ b/examples/00-basic/01-basic_operators.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_basic_operators_example:
 
@@ -48,12 +49,12 @@ print(disp_op.outputs)
 # Connect to the data sources of the model.
 disp_op.inputs.data_sources.connect(model.metadata.data_sources)
 
-# Create a field container norm operator and connect it to the
+# Create a fields container norm operator and connect it to the
 # displacement operator to chain the operators.
 norm_op = dpf.Operator("norm_fc")
 norm_op.inputs.connect(disp_op.outputs)
 
-# Create a field container min/max operator and connect it to the
+# Create a fields container min/max operator and connect it to the
 # output of the norm operator.
 mm_op = dpf.Operator("min_max_fc")
 mm_op.inputs.connect(norm_op.outputs)

--- a/examples/00-basic/02-basic_field_containers.py
+++ b/examples/00-basic/02-basic_field_containers.py
@@ -1,13 +1,14 @@
+# noqa: D400
 """
 .. _ref_basic_field_example:
 
 Field and field containers overview
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In DPF, the field is the main simulation data container. During a numerical
-simulation, result data is defined by values associated to entities
+simulation, the result data is defined by values associated to entities
 (scoping). These entities are a subset of a model (support).
 
-Because field data is always associated to its scoping and support,
+Because the field data is always associated to its scoping and support,
 the field is a self-describing piece of data. A field is also
 defined by its parameters, such as dimensionality, unit, and location.
 For example, a field can describe any of the following:

--- a/examples/00-basic/03-create_entities.py
+++ b/examples/00-basic/03-create_entities.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_create_entities_example:
 
@@ -27,11 +28,12 @@ mesh = dpf.MeshedRegion()
 
 
 def search_sequence_numpy(arr, seq):
+    """Find sequence in array and return its index."""
     indexes = np.where(np.isclose(arr, seq[0]))
     for index in np.nditer(indexes[0]):
         if index % 3 == 0:
             if np.allclose(arr[index + 1], seq[1]) and np.allclose(
-                    arr[index + 2], seq[2]
+                arr[index + 2], seq[2]
             ):
                 return index
     return -1
@@ -41,22 +43,22 @@ def search_sequence_numpy(arr, seq):
 # Add nodes:
 n_id = 1
 for i, x in enumerate(
-        [
-            float(i) * length / float(num_nodes_in_length)
-            for i in range(0, num_nodes_in_length)
-        ]
+    [
+        float(i) * length / float(num_nodes_in_length)
+        for i in range(0, num_nodes_in_length)
+    ]
 ):
     for j, y in enumerate(
-            [
-                float(i) * width / float(num_nodes_in_width)
-                for i in range(0, num_nodes_in_width)
-            ]
+        [
+            float(i) * width / float(num_nodes_in_width)
+            for i in range(0, num_nodes_in_width)
+        ]
     ):
         for k, z in enumerate(
-                [
-                    float(i) * depth / float(num_nodes_in_depth)
-                    for i in range(0, num_nodes_in_depth)
-                ]
+            [
+                float(i) * depth / float(num_nodes_in_depth)
+                for i in range(0, num_nodes_in_depth)
+            ]
         ):
             mesh.nodes.add_node(n_id, [x, y, z])
             n_id += 1
@@ -77,22 +79,22 @@ coordinates_scoping = coordinates.scoping
 # Add solid elements (linear hexa with eight nodes):
 e_id = 1
 for i, x in enumerate(
-        [
-            float(i) * length / float(num_nodes_in_length)
-            for i in range(0, num_nodes_in_length - 1)
-        ]
+    [
+        float(i) * length / float(num_nodes_in_length)
+        for i in range(0, num_nodes_in_length - 1)
+    ]
 ):
     for j, y in enumerate(
-            [
-                float(i) * width / float(num_nodes_in_width)
-                for i in range(0, num_nodes_in_width - 1)
-            ]
+        [
+            float(i) * width / float(num_nodes_in_width)
+            for i in range(0, num_nodes_in_width - 1)
+        ]
     ):
         for k, z in enumerate(
-                [
-                    float(i) * depth / float(num_nodes_in_depth)
-                    for i in range(0, num_nodes_in_depth - 1)
-                ]
+            [
+                float(i) * depth / float(num_nodes_in_depth)
+                for i in range(0, num_nodes_in_depth - 1)
+            ]
         ):
             coord1 = np.array([x, y, z])
             connectivity = []
@@ -117,12 +119,12 @@ mesh.plot()
 
 ###############################################################################
 # Create displacement fields over time with three time sets.
-# Here the displacement on each node is the value of its x, y, and
-# z coordinates for time 1.
-# The displacement on each node is two times the value of its x, y,
-# and z coordinates for time 2.
-# The displacement on each node is three times the value of its x,
-# y, and z coordinates for time 3.
+# For the first time set, the displacement on each node is the
+# value of its x, y, and z coordinates.
+# For the second time set, the displacement on each node is two
+# times the value of its x, y, and z coordinates.
+# For the third time set, the displacement on each node is three
+# times the value of its x, y, and z coordinates for time 3.
 num_nodes = mesh.nodes.n_nodes
 time1_array = coordinates_data
 time2_array = 2.0 * coordinates_data

--- a/examples/00-basic/04-basic-load-file.py
+++ b/examples/00-basic/04-basic-load-file.py
@@ -96,8 +96,27 @@ min_field = min_max_op.outputs.field_min()
 min_field.data
 
 ###############################################################################
-# Make sure that the original and the downloaded fields container are the same
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Compare the original and the downloaded fields container
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Subtract the two fields and plot an error map:
-error = fc_out - downloaded_fc_out
-mesh.plot(error.eval())
+abs_error = (fc_out - downloaded_fc_out).eval()
+
+divide = dpf.operators.math.component_wise_divide()
+divide.inputs.fieldA.connect(fc_out - downloaded_fc_out)
+divide.inputs.fieldB.connect(fc_out)
+scale = dpf.operators.math.scale()
+scale.inputs.field.connect(divide)
+scale.inputs.ponderation.connect(100.)
+rel_error = scale.eval()
+
+###############################################################################
+# Plot both absolute and relative error fields
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Note that the absolute error is bigger where the displacements are
+# bigger, at the tip of the geometry.
+# Instead, the relative error is similar accross the geometry since we
+# are dividing by the displacements ``fc_out``.
+# Both plots show errors that can be understood as zero up to machine precision
+# (1e-12 mm for the absolute error and 1e-5 % for the relative error).
+mesh.plot(abs_error, scalar_bar_args={'title': "Absolute error [mm]"})
+mesh.plot(rel_error, scalar_bar_args={'title': "Relative error [%]"})

--- a/examples/00-basic/04-basic-load-file.py
+++ b/examples/00-basic/04-basic-load-file.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_basic_load_file_example:
 
@@ -87,9 +88,16 @@ os.remove(downloaded_client_file_path)
 ###############################################################################
 # Make operations over the imported fields container
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use this fields container:
+# Use this fields container to get the minimum displacement:
 
 min_max_op = dpf.operators.min_max.min_max_fc()
 min_max_op.inputs.fields_container.connect(downloaded_fc_out)
 min_field = min_max_op.outputs.field_min()
 min_field.data
+
+###############################################################################
+# Make sure that the original and the downloaded fields container are the same
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Subtract the two fields and plot an error map:
+error = fc_out - downloaded_fc_out
+mesh.plot(error.eval())

--- a/examples/00-basic/07-use_result_helpers.py
+++ b/examples/00-basic/07-use_result_helpers.py
@@ -1,9 +1,11 @@
+# noqa: D400
 """
 .. _ref_use_result_helpers:
 
 Use result helpers to load custom data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``Result`` class, which is an instance created by the ``Model``, gives
+The :class:`Result <ansys.dpf.core.results.Result>` class, which is an instance
+created by the :class:`Model <ansys.dpf.core.model.Model>`, gives
 access to helpers for requesting results on specific mesh and time scopings.
 With these helpers, working on a custom spatial and temporal subset of the
 model is straightforward.

--- a/examples/00-basic/08-results_over_time_subset.py
+++ b/examples/00-basic/08-results_over_time_subset.py
@@ -1,9 +1,11 @@
+# noqa: D400
 """
 .. _ref_results_over_time:
 
 Scope results over custom time domains
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``Result`` class, which are instances created by the ``Model``, give
+The :class:`Result <ansys.dpf.core.results.Result>` class, which are instances
+created by the :class:`Model <ansys.dpf.core.model.Model>`, give
 access to helpers for requesting results on specific mesh and time scopings.
 With these helpers, working on a temporal subset of the
 model is straightforward. In this example, different ways to choose the temporal subset to

--- a/examples/00-basic/09-results_over_space_subset.py
+++ b/examples/00-basic/09-results_over_space_subset.py
@@ -1,9 +1,11 @@
+# noqa: D400
 """
 .. _ref_results_over_space:
 
 Scope results over custom space domains
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``Result`` class, which are instances created by the ``Model``, give
+The :class:`Result <ansys.dpf.core.results.Result>` class, which are instances
+created by the :class:`Model <ansys.dpf.core.model.Model>`, give
 access to helpers for requesting results on specific mesh and time scopings.
 With these helpers, working on a spatial subset of the model is straightforward.
 In this example, different ways to choose the spatial subset to
@@ -90,7 +92,7 @@ print(model.metadata.available_named_selections)
 ###############################################################################
 # Get the ``mesh_scoping`` of a named selection:
 
-mesh_scoping = model.metadata.named_selection('_CM82')
+mesh_scoping = model.metadata.named_selection("_CM82")
 print(mesh_scoping)
 
 ###############################################################################
@@ -100,13 +102,13 @@ model.metadata.meshed_region.plot(volume)
 
 ###############################################################################
 # Equivalent to:
-volume = model.results.elemental_volume.on_named_selection('_CM82')
+volume = model.results.elemental_volume.on_named_selection("_CM82")
 
 ###############################################################################
 # Equivalent to:
 ns_provider = dpf.operators.scoping.on_named_selection(
     requested_location=dpf.locations.elemental,
-    named_selection_name='_CM82',
+    named_selection_name="_CM82",
     data_sources=model,
 )
 volume = model.results.elemental_volume(mesh_scoping=ns_provider).eval()
@@ -161,8 +163,8 @@ scopings_container.add_scoping(
 
 ###############################################################################
 elemental_stress = model.results.stress.on_location(dpf.locations.elemental)(
-    mesh_scoping=scopings_container) \
-    .eval()
+    mesh_scoping=scopings_container
+).eval()
 print(elemental_stress)
 
 for field in elemental_stress:

--- a/examples/00-basic/11-server_types.py
+++ b/examples/00-basic/11-server_types.py
@@ -1,14 +1,15 @@
+# noqa: D400
 """
 .. _ref_server_types_example:
 
 Communicate in process or via gRPC
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Starting with Ansys 2022 R2, PyDPF can communication either In Process or via gRPC
+Starting with Ansys 2022 R2, PyDPF can communicate either via In Process or via gRPC
 with DPF C++ core server (``Ans.Dpf.Grpc.exe``). To choose which type of
 :class:`ansys.dpf.core.server_types.BaseServer` (object defining the type of communication
 and the server instance to communicate with) to use, a
 :class:`ansys.dpf.core.server_factory.ServerConfig` class should be used.
-Until Ansys 2022R1, only gRPC communication using python module ansys.grpc.dpf is supported
+Until Ansys 2022R1, only gRPC communication using python module ``ansys.grpc.dpf`` is supported
 (now called :class:`ansys.dpf.core.server_types.LegacyGrpcServer`), starting with Ansys 2022 R2,
 three types of servers are supported:
 
@@ -45,9 +46,7 @@ legacy_grpc_server = dpf.start_local_server(config=legacy_grpc_config)
 ###############################################################################
 # Equivalent to:
 
-in_process_config = dpf.ServerConfig(
-    protocol=None, legacy=False
-)
+in_process_config = dpf.ServerConfig(protocol=None, legacy=False)
 grpc_config = dpf.ServerConfig(
     protocol=dpf.server_factory.CommunicationProtocols.gRPC, legacy=False
 )
@@ -64,14 +63,14 @@ legacy_grpc_server = dpf.start_local_server(config=legacy_grpc_config, as_global
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 in_process_field = dpf.fields_factory.create_scalar_field(2, server=in_process_server)
-in_process_field.append([1.], 1)
-in_process_field.append([2.], 2)
+in_process_field.append([1.0], 1)
+in_process_field.append([2.0], 2)
 grpc_field = dpf.fields_factory.create_scalar_field(2, server=grpc_server)
-grpc_field.append([1.], 1)
-grpc_field.append([2.], 2)
+grpc_field.append([1.0], 1)
+grpc_field.append([2.0], 2)
 legacy_grpc_field = dpf.fields_factory.create_scalar_field(2, server=legacy_grpc_server)
-legacy_grpc_field.append([1.], 1)
-legacy_grpc_field.append([2.], 2)
+legacy_grpc_field.append([1.0], 1)
+legacy_grpc_field.append([2.0], 2)
 
 print(in_process_field, type(in_process_field._server), in_process_field._server)
 print(grpc_field, type(grpc_field._server), grpc_field._server)
@@ -87,8 +86,8 @@ initial_config = dpf.SERVER_CONFIGURATION
 
 dpf.SERVER_CONFIGURATION = dpf.AvailableServerConfigs.GrpcServer
 grpc_field = dpf.fields_factory.create_scalar_field(2)
-grpc_field.append([1.], 1)
-grpc_field.append([2.], 2)
+grpc_field.append([1.0], 1)
+grpc_field.append([2.0], 2)
 print(grpc_field, type(grpc_field._server), grpc_field._server)
 
 # Go back to default config:

--- a/examples/00-basic/13-nodes_in_local_coordinate_system.py
+++ b/examples/00-basic/13-nodes_in_local_coordinate_system.py
@@ -1,17 +1,16 @@
+# noqa: D400
 """
 .. _ref_nodes_in_local_coordinate_system:
 
 Convert nodal coordinates field to local coordinate system
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-GCS: Global Coordinate System
-LCS: Local Coordinate System
-Currently, there is no native operator to get nodal coordinates in an LCS.
-The operator :class: `rotate <ansys.dpf.core.operators.geo.rotate.rotate>`
-rotates the input field in GCS as per the input rotation matrix. So, if the LCS
-is at the same origin as the GCS, only one operation using the `rotate`
-operator give the desired output. But for an LCS with a transformed origin,
-after rotation a transformation along the rotated position vector of LCS's
-origin is also needed to get the correct coordinates in LCS.
+Currently, there is no native operator to get nodal coordinates in an Local
+Coordinate System (LCS). The operator :class:`rotate <ansys.dpf.core.operators.geo.rotate.rotate>`
+rotates the input field in Global Coordinate System (GCS) as per the input rotation matrix.
+So, if the LCS is at the same origin as the GCS, only one operation using the
+:class:`rotate <ansys.dpf.core.operators.geo.rotate.rotate>` operator give the desired output.
+However, if the aim is to obtain the LCS in a case where the LCS origin does not coincide with
+the GCS, a transformation is required after the rotation to get the correct coordinates in LCS.
 
 The script below demonstrates the methodology using PyDPF.
 
@@ -26,45 +25,43 @@ from ansys.dpf.core import examples
 model = dpf.Model(examples.download_hemisphere())
 
 ###############################################################################
-# Get the property `coordinates_field` from :class: nodes ansys.dpf.core.nodes`
+# Get the property ``coordinates_field`` from :class:`nodes <ansys.dpf.core.nodes>`:
 ncoord_f = model.metadata.meshed_region.nodes.coordinates_field
 
 ###############################################################################
-# Get the rotation matrix of the LCS ID 12
-# The first 9 values in the `cs` output is the rotation matrix
+# Get the rotation matrix of the LCS ID 12.
+# The first 9 values in the ``cs`` output is the rotation matrix.
 cs = model.operator(r"mapdl::rst::CS")
 cs.inputs.cs_id.connect(12)
 cs_rot_mat = cs.outputs.field.get_data().data.T[0:9]
 
 ###############################################################################
-# Create a 3x3 rotation matrix field - `rot_mat_f`
+# Create a 3x3 rotation matrix field ``rot_mat_f``:
 rot_mat_f = dpf.fields_factory.create_scalar_field(1)
 rot_mat_f.data = cs_rot_mat
 
 ###############################################################################
 # Create a 3D vector field for the position vector of the LCS's origin and
 # rotate the origin as per the rotation matrix of the LCS.
-# The last 3 entries of `cs` output is the LCS's origin in GCS.
+# The last 3 entries of ``cs`` output is the LCS's origin in GCS.
 pos_vec = dpf.fields_factory.create_3d_vector_field(1)
 pos_vec.data = cs.outputs.field.get_data().data.T[-3:]
-pos_vec_rot = dpf.operators.geo.rotate(field=pos_vec,
-                                       field_rotation_matrix=rot_mat_f)
+pos_vec_rot = dpf.operators.geo.rotate(field=pos_vec, field_rotation_matrix=rot_mat_f)
 
 ###############################################################################
-# Get rotated nodal coordinates field.
-ncoord_rot_f = dpf.operators.geo.rotate(field=ncoord_f,
-                                        field_rotation_matrix=rot_mat_f)
+# Get rotated nodal coordinates field:
+ncoord_rot_f = dpf.operators.geo.rotate(field=ncoord_f, field_rotation_matrix=rot_mat_f)
 
 ###############################################################################
-# Transform rotated nodal coordinates field along rotated position vector -
-# `pos_vec_rot`,
-pos_vec_rot_neg_f = dpf.operators.math.scale(field=pos_vec_rot,
-                                             ponderation=-1.0)
+# Transform rotated nodal coordinates field along rotated position vector
+# ``pos_vec_rot``:
+pos_vec_rot_neg_f = dpf.operators.math.scale(field=pos_vec_rot, ponderation=-1.0)
 pos_vec_rot_neg = pos_vec_rot_neg_f.outputs.field.get_data().data_as_list
-ncoord_translate = dpf.operators.math.add_constant(field=ncoord_rot_f,
-                                                   ponderation=pos_vec_rot_neg)
+ncoord_translate = dpf.operators.math.add_constant(
+    field=ncoord_rot_f, ponderation=pos_vec_rot_neg
+)
 ###############################################################################
-# Get the nodal coordinates field `ncoord_lcs_f` in LCS
+# Get the nodal coordinates field ``ncoord_lcs_f`` in LCS:
 ncoord_lcs_f = ncoord_translate.outputs.field.get_data()
 
 ###############################################################################

--- a/examples/01-static-transient/00-basic_transient.py
+++ b/examples/01-static-transient/00-basic_transient.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_basic_transient:
 
@@ -143,8 +144,8 @@ for node_id in node_ids[:10]:
 
 ###############################################################################
 # Rather than individually querying for each node coordinate of the
-# field, you can use the :func:`map_scoping` to remap the field data
-# to match the order of the nodes in the meshed region.
+# field, you can use the :func:`map_scoping <ansys.dpf.core.nodes.Nodes.map_scoping>`
+# to remap the field data to match the order of the nodes in the meshed region.
 #
 # Obtain the indices needed to get the data from ``field.data`` to match
 # the order of nodes in the mesh:

--- a/examples/01-static-transient/01-transient_easy_time_scoping.py
+++ b/examples/01-static-transient/01-transient_easy_time_scoping.py
@@ -1,9 +1,10 @@
+# noqa: D400
 """
 .. _ref_transient_easy_time_scoping:
 
 Choose a time scoping for a transient analysis
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This example shows how to use a model's results to choose a time scoping.
+This example shows how to use a model's result to choose a time scoping.
 
 """
 import matplotlib.pyplot as plt

--- a/examples/02-modal-harmonic/01-modal_cyclic.py
+++ b/examples/02-modal-harmonic/01-modal_cyclic.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_basic_cyclic:
 
@@ -19,7 +20,10 @@ print(model)
 # Expand displacement results
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This example expands displacement results, by default on all
-# nodes and the first time step.
+# nodes and the first time step. Note that the displacements are expanded using
+# the :func:`read_cyclic 
+# <ansys.dpf.core.operators.mesh.mesh_provider.InputsMeshProvider.read_cyclic>`
+# prpoerty with 2 as an argument (1 would ignore the cyclic symmetry).
 
 # Create displacement cyclic operator
 u_cyc = model.operator("mapdl::rst::U_cyclic")

--- a/examples/02-modal-harmonic/02-cyclic_multi_stage.py
+++ b/examples/02-modal-harmonic/02-cyclic_multi_stage.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_multi_stage_cyclic:
 
@@ -20,7 +21,10 @@ print(model)
 # Expand displacement results
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This example expands displacement results, by default on all
-# nodes and the first time step.
+# nodes and the first time step. Note that the displacements are expanded using
+# the :func:`read_cyclic
+# <ansys.dpf.core.operators.mesh.mesh_provider.InputsMeshProvider.read_cyclic>`
+# prpoerty with 2 as an argument (1 would ignore the cyclic symmetry).
 
 # Create displacement cyclic operator
 UCyc = model.results.displacement()

--- a/examples/02-modal-harmonic/03-compare_modes.py
+++ b/examples/02-modal-harmonic/03-compare_modes.py
@@ -1,9 +1,11 @@
+# noqa: D400
 """
 .. _ref_compare_modes:
 
 Use Result Helpers to compare mode shapes for solids and then shells
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The `Result` class which instances are created by the `Model` gives access to
+The :class:`Result <ansys.dpf.core.results.Result>` class which instances
+are created by the :class:`Model <ansys.dpf.core.model.Model>` gives access to
 helpers to request results on specific mesh and time scopings.
 With those helpers, working on a custom spatial and temporal subset of the
 model is straightforward.

--- a/examples/03-advanced/03-exchange_data_between_servers.py
+++ b/examples/03-advanced/03-exchange_data_between_servers.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_exchange_data_between_servers.:
 
@@ -16,18 +17,25 @@ from ansys.dpf.core import operators as ops
 ###############################################################################
 # Create two servers
 # ~~~~~~~~~~~~~~~~~~
-# Use the ``start_local_server()`` method to start two servers on your local
-# machine. If you have another server, you can use the ``connect_to_server()``
+# Use the :func:`start_local_server() <ansys.dpf.core.server.start_local_server>`
+# method to start two servers on your local machine. If you have another server,
+# you can use the :func:`connect_to_server() <ansys.dpf.core.server.connect_to_server>`
 # method to connect to any DPF server on your network.
-
+#
 # The ``as_global`` attributes allows you to choose whether a server is stored
 # by the module and used by default. This example sets the first server as the default.
-server1 = dpf.start_local_server(as_global=True, config=dpf.AvailableServerConfigs.GrpcServer)
-server2 = dpf.start_local_server(as_global=False, config=dpf.AvailableServerConfigs.GrpcServer)
+server1 = dpf.start_local_server(
+    as_global=True, config=dpf.AvailableServerConfigs.GrpcServer
+)
+server2 = dpf.start_local_server(
+    as_global=False, config=dpf.AvailableServerConfigs.GrpcServer
+)
 
 # Check that the two servers are listening on different ports.
-print(server1.port if hasattr(server1, "port") else "",
-      server2.port if hasattr(server2, "port") else "")
+print(
+    server1.port if hasattr(server1, "port") else "",
+    server2.port if hasattr(server2, "port") else "",
+)
 
 ###############################################################################
 # Send the result file

--- a/examples/03-advanced/05-extrapolation_strain_2d.py
+++ b/examples/03-advanced/05-extrapolation_strain_2d.py
@@ -1,11 +1,12 @@
+# noqa: D400
 """
 .. _extrapolation_test_strain_2Delement:
 
 Extrapolation method for strain result of a 2D element
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This example shows how to compute the nodal component elastic strain
-from Gaussian points (integration points) for a 2D element by using the
-extrapolation method.
+This example shows how to compute the stress nodal components from
+Gaussian points (integration points) for a 2D element using
+extrapolation.
 
 Extrapolate results available at Gaussian or quadrature points to nodal
 points for a field or fields container. The available elements are:
@@ -21,7 +22,7 @@ Here are the steps for extrapolation:
 
 #. Get the data source's solution from the integration points. (This
    result file was generated with the Ansys Mechanical APDL (MAPDL)
-   option ``EREXS, NO``).
+   option ``ERESX, NO``).
 #. Use the extrapolation operator to compute the nodal elastic strain.
 #. Get the result for nodal elastic strain from the data source.
    The analysis was computed by MAPDL.
@@ -119,14 +120,40 @@ mesh.plot(strain_ref_nodal_op.outputs.fields_container())
 # ~~~~~~~~~~~~
 # Compare the elastic strain result computed by extrapolation and reference's result.
 # Check if the two fields containers are identical.
-# The maximum tolerance gap between two compared values is 1e-3.
+# The relative tolerance is set to 1e-14.
 # The smallest value that is to be considered during the comparison
-# step : all the ``abs(values)`` in the field less than 1e-14 are considered null.
+# step : all the ``abs(values)`` in the field less than 1e-2 are considered null.
 
 # operator AreFieldsIdentical_fc
 op = dpf.operators.logic.identical_fc()
-op.inputs.fields_containerA.connect(fex)
-op.inputs.fields_containerB.connect(strain_ref)
+op.inputs.fields_containerA.connect(fex_nodal_op)
+op.inputs.fields_containerB.connect(strain_ref_nodal_op)
 op.inputs.tolerance.connect(1.0e-14)
-op.inputs.small_value.connect(0.001)
-op.outputs.boolean()
+op.inputs.small_value.connect(0.01)
+print(op.outputs.boolean())
+
+###############################################################################
+# Compute absolute and relative errors
+abs_error_sqr = dpf.operators.math.sqr_fc()
+abs_error = dpf.operators.math.sqrt_fc()
+error = strain_ref_nodal_op - fex_nodal_op
+abs_error_sqr.inputs.fields_container.connect(error)
+abs_error.inputs.fields_container.connect(abs_error_sqr)
+
+
+divide = dpf.operators.math.component_wise_divide()
+divide.inputs.fieldA.connect(strain_ref_nodal_op - fex_nodal_op)
+divide.inputs.fieldB.connect(strain_ref_nodal_op)
+rel_error = dpf.operators.math.scale()
+rel_error.inputs.field.connect(divide)
+rel_error.inputs.ponderation.connect(1.0)
+
+###############################################################################
+# Plot absolute and relative errors.
+# The absolute value is the order of 1e-13, which is very small when compared to the
+# magnitude of 1e-5 of the displacements. This is reflected in the relative error
+# plot, where the errors are found to be below 1.1e-5%. The result of these plots
+# can be used to set the tolerances for the
+# :class:`identical_fc <ansys.dpf.core.operators.logic.identical_fc>` operator.
+mesh.plot(abs_error.eval(), scalar_bar_args={"title": "Absolute error [mm]"})
+mesh.plot(rel_error.eval(), scalar_bar_args={"title": "Relative error [%]"})

--- a/examples/03-advanced/06-stress_gradient_path.py
+++ b/examples/03-advanced/06-stress_gradient_path.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _stress_gradient_path:
 
@@ -15,10 +16,11 @@ A path is created of a defined length.
 # included examples file and ``DpfPlotter``.
 #
 import matplotlib.pyplot as plt
+
 from ansys.dpf import core as dpf
+from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 from ansys.dpf.core.plotter import DpfPlotter
-from ansys.dpf.core import examples
 
 ###############################################################################
 # Open an example and print out the ``Model`` object. The
@@ -38,7 +40,7 @@ path = examples.download_hemisphere()
 model = dpf.Model(path)
 print(model)
 ###############################################################################
-# Define the node ID normal to plot the a stress gradient to.
+# Define the node ID normal to plot the a stress gradient
 #
 node_id = 1928
 ###############################################################################
@@ -47,9 +49,9 @@ node_id = 1928
 unit = model.metadata.meshed_region.unit
 print("Unit: %s" % unit)
 ###############################################################################
-# `depth` defines the length/depth that the path penetrates to.
-# While defining `depth` make sure you use the correct mesh unit.
-# `delta` defines distance between consecutive points on the path.
+# ``depth`` defines the length/depth that the path penetrates to.
+# While defining ``depth`` make sure you use the correct mesh unit.
+# ``delta`` defines distance between consecutive points on the path.
 depth = 10  # in mm
 delta = 0.1  # in mm
 ###############################################################################
@@ -63,17 +65,19 @@ stress_fc = model.results.stress().eqv().eval()
 ###############################################################################
 # Define Nodal scoping.
 # Make sure to define ``"Nodal"`` as the requested location, important for the
-# `normals` operator.
+# :class:`normals <ansys.dpf.core.operators.geo.normals.normals>` operator.
 #
 nodal_scoping = dpf.Scoping(location=dpf.locations.nodal)
 nodal_scoping.ids = [node_id]
 ###############################################################################
-# Get Skin Mesh because `normals` operator requires Shells as input.
+# Get Skin Mesh because :class:`normals <ansys.dpf.core.operators.geo.normals.normals>`
+# operator requires Shells as input.
 #
 skin_mesh = ops.mesh.skin(mesh=mesh)
 skin_meshed_region = skin_mesh.outputs.mesh.get_data()
 ###############################################################################
-# Get normal at a node using `normals` operator.
+# Get normal at a node using :class:`normals <ansys.dpf.core.operators.geo.normals.normals>`
+# operator.
 #
 normal = ops.geo.normals()
 normal.inputs.mesh.connect(skin_meshed_region)
@@ -81,11 +85,10 @@ normal.inputs.mesh_scoping.connect(nodal_scoping)
 normal_vec_out_field = normal.outputs.field.get_data()
 ###############################################################################
 # The normal vector is along the surface normal. You need to invert the vector
-# using `math.scale` operator inwards in the geometry, to get the path
-# direction.
+# using :class:`scale <ansys.dpf.core.operators.math.scale.scale>` operator
+# inwards in the geometry, to get the path direction.
 #
-normal_vec_in_field = ops.math.scale(field=normal_vec_out_field,
-                                     ponderation=-1.0)
+normal_vec_in_field = ops.math.scale(field=normal_vec_out_field, ponderation=-1.0)
 normal_vec_in = normal_vec_in_field.outputs.field.get_data().data[0]
 ###############################################################################
 # Get nodal coordinates, they serve as the first point on the line.
@@ -101,8 +104,9 @@ fz = lambda t: line_fp[2] + normal_vec_in[2] * t
 ###############################################################################
 # Create coordinates using 3D line equation.
 #
-coordinates = [[fx(t * delta), fy(t * delta), fz(t * delta)] for t in
-               range(int(depth / delta))]
+coordinates = [
+    [fx(t * delta), fy(t * delta), fz(t * delta)] for t in range(int(depth / delta))
+]
 flat_coordinates = [entry for data in coordinates for entry in data]
 ###############################################################################
 # Create field for coordinates of the path.
@@ -113,10 +117,8 @@ field_coord.scoping.ids = list(range(1, len(coordinates) + 1))
 ###############################################################################
 # Map results on the path.
 mapping_operator = ops.mapping.on_coordinates(
-    fields_container=stress_fc,
-    coordinates=field_coord,
-    create_support=True,
-    mesh=mesh)
+    fields_container=stress_fc, coordinates=field_coord, create_support=True, mesh=mesh
+)
 fields_mapped = mapping_operator.outputs.fields_container()
 ###############################################################################
 # Request the mapped field data and its mesh.
@@ -132,14 +134,12 @@ plt.xlabel("Length (%s)" % mesh.unit)
 plt.ylabel("Stress (%s)" % field_m.unit)
 plt.show()
 ###############################################################################
-# Create a plot to add both meshes to.
-# ``mesh_m`` - mapped mesh
-# ``mesh`` - original mesh
+# Create a plot to add both meshes, ``mesh_m`` (the mapped mesh) and ``mesh``
+# (the original mesh)
 pl = DpfPlotter()
 pl.add_field(field_m, mesh_m)
-pl.add_mesh(mesh, style="surface", show_edges=True,
-            color="w", opacity=0.3)
-pl.show_figure(show_axes=True, cpos=[
-    (62.687, 50.119, 67.247),
-    (5.135, 6.458, -0.355),
-    (-0.286, 0.897, -0.336)])
+pl.add_mesh(mesh, style="surface", show_edges=True, color="w", opacity=0.3)
+pl.show_figure(
+    show_axes=True,
+    cpos=[(62.687, 50.119, 67.247), (5.135, 6.458, -0.355), (-0.286, 0.897, -0.336)],
+)

--- a/examples/04-specific-requests/00-hdf5_double_float_comparison.py
+++ b/examples/04-specific-requests/00-hdf5_double_float_comparison.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_basic_hdf5:
 
@@ -57,24 +58,21 @@ h5op.inputs.data3.connect(mesh)
 ###############################################################################
 # Export with simple precision.
 
-directory = "c:/temp/"
-if os.name == "posix":
-    directory = "/tmp/"
-
-h5op.inputs.file_path.connect(os.path.join(tmpdir, directory, "dpf_float.h5"))
+h5op.inputs.file_path.connect(os.path.join(tmpdir, "dpf_float.h5"))
 h5op.run()
 
 ###############################################################################
 # Export with double precision.
 
 h5op.inputs.export_floats.connect(False)
-h5op.inputs.file_path.connect(os.path.join(tmpdir, directory, "dpf_double.h5"))
+h5op.inputs.file_path.connect(os.path.join(tmpdir, "dpf_double.h5"))
 h5op.run()
 
 ###############################################################################
 # Compare simple precision versus double precision.
-float_precision = os.stat(os.path.join(tmpdir, directory, "dpf_float.h5")).st_size
-double_precision = os.stat(os.path.join(tmpdir, directory, "dpf_double.h5")).st_size
+float_precision = os.stat(os.path.join(tmpdir, "dpf_float.h5")).st_size
+double_precision = os.stat(os.path.join(tmpdir, "dpf_double.h5")).st_size
+# double_precision = os.stat(os.path.join(tmpdir, directory, "dpf_double.h5")).st_size
 print(
     f"size with float precision: {float_precision}\n"
     f"size with double precision: {double_precision}"

--- a/examples/05-plotting/02-solution_combination.py
+++ b/examples/05-plotting/02-solution_combination.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _solution_combination:
 
@@ -17,7 +18,7 @@ from ansys.dpf.core.plotter import DpfPlotter
 
 ###############################################################################
 # Open an example and print the ``Model`` object. The
-# # :class:`Model <ansys.dpf.core.model.Model>` class helps to organize access
+# :class:`Model <ansys.dpf.core.model.Model>` class helps to organize access
 # methods for the result by keeping track of the operators and data sources
 # used by the result file.
 #
@@ -33,7 +34,7 @@ print(model)
 
 ###############################################################################
 # Get the stress tensor and ``connect`` time scoping.
-# # Make sure that you define ``"Nodal"`` as the scoping location because
+# Make sure that you define ``"Nodal"`` as the scoping location because
 # labels are supported only for nodal results.
 #
 stress_tensor = model.results.stress()
@@ -43,21 +44,17 @@ stress_tensor.inputs.time_scoping.connect(time_scope)
 stress_tensor.inputs.requested_location.connect("Nodal")
 
 ###############################################################################
-# This code performs solution combination on two load cases.
-# =>LC1 - LC2
+# This code performs solution combination on two load cases, LC1 and LC2.
 # You can access individual load cases as the fields of a fields container for
-# The stress tensor.
-# LC1: stress_tensor.outputs.fields_container.get_data()[0]
-# LC2: stress_tensor.outputs.fields_container.get_data()[1]
-#
-# Scale LC2 to -1.
+# the stress tensor.
+field_lc1 = stress_tensor.outputs.fields_container.get_data()[0]
 field_lc2 = stress_tensor.outputs.fields_container.get_data()[1]
+
+# Scale LC2 to -1.
 stress_tensor_lc2_sc = dpf.operators.math.scale(field=field_lc2, ponderation=-1.0)
 
 ###############################################################################
 # Add load cases.
-#
-field_lc1 = stress_tensor.outputs.fields_container.get_data()[0]
 stress_tensor_combi = dpf.operators.math.add(
     fieldA=field_lc1, fieldB=stress_tensor_lc2_sc
 )

--- a/examples/05-plotting/04-plot_on_path.py
+++ b/examples/05-plotting/04-plot_on_path.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _plot_on_path:
 
@@ -7,6 +8,8 @@ This example shows how to get a result mapped over a specific path
 and how to plot it.
 
 """
+
+import matplotlib.pyplot as plt
 
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
@@ -27,9 +30,11 @@ stress_fc = model.results.stress().eqv().eval()
 ###############################################################################
 # Create a coordinates field to map on.
 coordinates = [[0.024, 0.03, 0.003]]
-for i in range(1, 51):
+delta = 0.001
+n_points = 51
+for i in range(1, n_points):
     coord_copy = coordinates[0].copy()
-    coord_copy[1] = coord_copy[0] + i * 0.001
+    coord_copy[1] = coord_copy[0] + i * delta
     coordinates.append(coord_copy)
 field_coord = dpf.fields_factory.create_3d_vector_field(len(coordinates))
 field_coord.data = coordinates
@@ -38,10 +43,8 @@ field_coord.scoping.ids = list(range(1, len(coordinates) + 1))
 ###############################################################################
 # Compute the mapped data using the mapping operator.
 mapping_operator = ops.mapping.on_coordinates(
-    fields_container=stress_fc,
-    coordinates=field_coord,
-    create_support=True,
-    mesh=mesh)
+    fields_container=stress_fc, coordinates=field_coord, create_support=True, mesh=mesh
+)
 fields_mapped = mapping_operator.outputs.fields_container()
 
 ###############################################################################
@@ -54,8 +57,18 @@ mesh_m = field_m.meshed_region
 pl = DpfPlotter()
 
 pl.add_field(field_m, mesh_m)
-pl.add_mesh(mesh, style="surface", show_edges=True,
-            color="w", opacity=0.3)
+pl.add_mesh(mesh, style="surface", show_edges=True, color="w", opacity=0.3)
 
 # Plot the result.
 pl.show_figure(show_axes=True)
+
+###############################################################################
+# Plot the solution along the specified line. Note that since the line is only
+# moving along the y-axis, the stresses are plotted with respect to the y coordinate.
+y_coords = [
+    mesh_m.nodes.coordinates_field.data[i][1] for i in range(mesh_m.nodes.n_nodes)
+]
+plt.plot(y_coords, field_m.data, "r")
+plt.xlabel(f"y-coordinate [{mesh.unit}]")
+plt.ylabel(f"Stress [{field_m.unit}]")
+plt.show()

--- a/examples/07-python-operators/01-package_python_operators.py
+++ b/examples/07-python-operators/01-package_python_operators.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_python_plugin_package:
 
@@ -12,7 +13,7 @@ The benefits of writing packages rather than simple scripts are:
 
 For this example, the plug-in package contains two different operators:
 
-- One that returns all scoping ID having data higher than the average
+- One that returns all scoping IDs having data higher than the average
 - One that returns all scoping IDs having data lower than the average
 
 """
@@ -29,13 +30,16 @@ For this example, the plug-in package contains two different operators:
 # created for you.
 
 import os
+
 from ansys.dpf.core import examples
 
-print('\033[1m average_filter_plugin')
+print("\033[1m average_filter_plugin")
 file_list = ["__init__.py", "operators.py", "operators_loader.py", "common.py"]
 plugin_folder = None
-GITHUB_SOURCE_URL = "https://github.com/pyansys/pydpf-core/raw/" \
-                    "examples/first_python_plugins/python_plugins/average_filter_plugin"
+GITHUB_SOURCE_URL = (
+    "https://github.com/pyansys/pydpf-core/raw/"
+    "examples/first_python_plugins/python_plugins/average_filter_plugin"
+)
 
 for file in file_list:
     EXAMPLE_FILE = GITHUB_SOURCE_URL + "/average_filter_plugin/" + file
@@ -43,10 +47,10 @@ for file in file_list:
         EXAMPLE_FILE, file, "python_plugins/average_filter_plugin"
     )
     plugin_folder = os.path.dirname(operator_file_path)
-    print(f'\033[1m {file}:\n \033[0m')
+    print(f"\033[1m {file}:\n \033[0m")
     with open(operator_file_path, "r") as f:
         for line in f.readlines():
-            print('\t\t\t' + line)
+            print("\t\t\t" + line)
     print("\n\n")
 
 
@@ -58,12 +62,14 @@ for file in file_list:
 #
 # - The first argument is the path to the directory where the plug-in package
 #   is located.
-# - The second argument is ``py_`` plus any name identifying the plug-in package.
-# - The third argument is the name of the function exposed in the ``__init__ file``
+# - The second argument is ``py_<package>``, where ``<package>`` is the name
+#   identifying the plug-in package.
+# - The third argument is the name of the function exposed in the ``__init__`` file
 #   for the plug-in package that is used to record operators.
 #
 
 import os
+
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
@@ -72,13 +78,13 @@ dpf.start_local_server(config=dpf.AvailableServerConfigs.GrpcServer)
 
 tmp = dpf.make_tmp_dir_server()
 dpf.upload_files_in_folder(
-    dpf.path_utilities.join(tmp, "average_filter_plugin"),
-    plugin_folder
+    dpf.path_utilities.join(tmp, "average_filter_plugin"), plugin_folder
 )
 dpf.load_library(
     os.path.join(dpf.path_utilities.join(tmp, "average_filter_plugin")),
     "py_average_filter",
-    "load_operators")
+    "load_operators",
+)
 
 ###############################################################################
 # Instantiate the operator.

--- a/examples/07-python-operators/02-python_operators_with_dependencies.py
+++ b/examples/07-python-operators/02-python_operators_with_dependencies.py
@@ -1,3 +1,4 @@
+# noqa: D400
 """
 .. _ref_python_operators_with_deps:
 
@@ -25,33 +26,43 @@ file at the given path.
 # and a call to the :py:func:`ansys.dpf.core.custom_operator.record_operator`
 # method, which records the operators of the plug-in package.
 #
-# Download the ```gltf_plugin`` plug-in package that has already been
+# Download the ``gltf_plugin`` plug-in package that has already been
 # created for you.
 
 import os
+
 from ansys.dpf.core import examples
 
-print('\033[1m gltf_plugin')
-file_list = ["gltf_plugin/__init__.py", "gltf_plugin/operators.py",
-             "gltf_plugin/operators_loader.py", "gltf_plugin/requirements.txt",
-             "gltf_plugin/gltf_export.py", "gltf_plugin/texture.png", "gltf_plugin.xml"
-             ]
+print("\033[1m gltf_plugin")
+file_list = [
+    "gltf_plugin/__init__.py",
+    "gltf_plugin/operators.py",
+    "gltf_plugin/operators_loader.py",
+    "gltf_plugin/requirements.txt",
+    "gltf_plugin/gltf_export.py",
+    "gltf_plugin/texture.png",
+    "gltf_plugin.xml",
+]
 plugin_path = None
-GITHUB_SOURCE_URL = "https://github.com/pyansys/pydpf-core/raw/" \
-                    "" \
-                    "examples/first_python_plugins/python_plugins"
+GITHUB_SOURCE_URL = (
+    "https://github.com/pyansys/pydpf-core/raw/"
+    ""
+    "examples/first_python_plugins/python_plugins"
+)
 
 for file in file_list:
     EXAMPLE_FILE = GITHUB_SOURCE_URL + "/gltf_plugin/" + file
     operator_file_path = examples.downloads._retrieve_file(
-        EXAMPLE_FILE, file, os.path.join("python_plugins", os.path.dirname(file)))
+        EXAMPLE_FILE, file, os.path.join("python_plugins", os.path.dirname(file))
+    )
 
-    print(f'\033[1m {file}\n \033[0m')
-    if (os.path.splitext(file)[1] == ".py" or os.path.splitext(file)[1] == ".xml") \
-            and file != "gltf_plugin/gltf_export.py":
+    print(f"\033[1m {file}\n \033[0m")
+    if (
+        os.path.splitext(file)[1] == ".py" or os.path.splitext(file)[1] == ".xml"
+    ) and file != "gltf_plugin/gltf_export.py":
         with open(operator_file_path, "r") as f:
             for line in f.readlines():
-                print('\t\t\t' + line)
+                print("\t\t\t" + line)
         print("\n\n")
         if plugin_path is None:
             plugin_path = os.path.dirname(operator_file_path)
@@ -74,10 +85,10 @@ for file in file_list:
 #
 # To simplify this step, you can add a requirements file in the plug-in package:
 #
-print(f'\033[1m gltf_plugin/requirements.txt: \n \033[0m')
+print(f"\033[1m gltf_plugin/requirements.txt: \n \033[0m")
 with open(os.path.join(plugin_path, "requirements.txt"), "r") as f:
     for line in f.readlines():
-        print('\t\t\t' + line)
+        print("\t\t\t" + line)
 
 
 # %%
@@ -110,32 +121,43 @@ with open(os.path.join(plugin_path, "requirements.txt"), "r") as f:
 #    create_sites_for_python_operators.sh -pluginpath /path/to/plugin -zippath /path/to/plugin/assets/linx64.zip # noqa: E501
 
 
-if os.name == "nt" and \
-        not os.path.exists(os.path.join(plugin_path, 'assets', 'gltf_sites_winx64.zip')):
+if os.name == "nt" and not os.path.exists(
+    os.path.join(plugin_path, "assets", "gltf_sites_winx64.zip")
+):
     CMD_FILE_URL = GITHUB_SOURCE_URL + "/create_sites_for_python_operators.ps1"
     cmd_file = examples.downloads._retrieve_file(
-        CMD_FILE_URL, "create_sites_for_python_operators.ps1", "python_plugins")
+        CMD_FILE_URL, "create_sites_for_python_operators.ps1", "python_plugins"
+    )
     run_cmd = f"powershell {cmd_file}"
-    args = f" -pluginpath \"{plugin_path}\" " \
-           f"-zippath {os.path.join(plugin_path, 'assets', 'gltf_sites_winx64.zip')}"
+    args = (
+        f' -pluginpath "{plugin_path}" '
+        f"-zippath {os.path.join(plugin_path, 'assets', 'gltf_sites_winx64.zip')}"
+    )
     print(run_cmd + args)
     import subprocess
-    process = subprocess.run(run_cmd + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    process = subprocess.run(
+        run_cmd + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     if process.stderr:
         raise RuntimeError(
             "Installing pygltf in a virtual environment failed with error:\n"
-            + process.stderr.decode())
+            + process.stderr.decode()
+        )
     else:
         print("Installing pygltf in a virtual environment succeeded")
-elif os.name == "posix" and \
-        not os.path.exists(os.path.join(plugin_path, 'assets', 'gltf_sites_linx64.zip')):
+elif os.name == "posix" and not os.path.exists(
+    os.path.join(plugin_path, "assets", "gltf_sites_linx64.zip")
+):
     CMD_FILE_URL = GITHUB_SOURCE_URL + "/create_sites_for_python_operators.sh"
     cmd_file = examples.downloads._retrieve_file(
         CMD_FILE_URL, "create_sites_for_python_operators.ps1", "python_plugins"
     )
     run_cmd = f"{cmd_file}"
-    args = f" -pluginpath \"{plugin_path}\" " \
-           f"-zippath \"{os.path.join(plugin_path, 'assets', 'gltf_sites_linx64.zip')}\""
+    args = (
+        f' -pluginpath "{plugin_path}" '
+        f"-zippath \"{os.path.join(plugin_path, 'assets', 'gltf_sites_linx64.zip')}\""
+    )
     print(run_cmd + args)
     os.system(f"chmod u=rwx,o=x {cmd_file}")
     os.system(run_cmd + args)
@@ -149,8 +171,9 @@ elif os.name == "posix" and \
 #
 # - The first argument is the path to the directory where the plug-in package
 #   is located.
-# - The second argument is ``py_`` plus any name identifying the plug-in package.
-# - The third argument is the name of the function exposed in the ``__init__ file``
+# - The second argument is ``py_<package>``, where ``<package>`` is the name
+#   identifying the plug-in package.
+# - The third argument is the name of the function exposed in the ``__init__`` file
 #   for the plug-in package that is used to record operators.
 
 from ansys.dpf import core as dpf
@@ -161,18 +184,17 @@ dpf.start_local_server(config=dpf.AvailableServerConfigs.GrpcServer)
 
 tmp = dpf.make_tmp_dir_server()
 dpf.upload_files_in_folder(
-    dpf.path_utilities.join(tmp, "plugins", "gltf_plugin"),
-    plugin_path
+    dpf.path_utilities.join(tmp, "plugins", "gltf_plugin"), plugin_path
 )
 dpf.upload_file(
-    plugin_path + ".xml",
-    dpf.path_utilities.join(tmp, "plugins", "gltf_plugin.xml")
+    plugin_path + ".xml", dpf.path_utilities.join(tmp, "plugins", "gltf_plugin.xml")
 )
 
 dpf.load_library(
     dpf.path_utilities.join(tmp, "plugins", "gltf_plugin"),
     "py_dpf_gltf",
-    "load_operators")
+    "load_operators",
+)
 
 ###############################################################################
 # Instantiate the operator.


### PR DESCRIPTION
Improvements in the example section. 

- Several modifications in the examples descriptions to fix typos, class and function paths and to rewrite some sentences.
- Addition of absolute and relative error plots when two fields are compared.
- Addition of line plot when mapping field to a path.

@PProfizi, @MaxJPRey, feedback will be greatly appreciated.