### PR TITLE
Define the default server context with ANSYS_DPF_SERVER_CONTEXT

### DIFF
--- a/ansys/dpf/core/server_context.py
+++ b/ansys/dpf/core/server_context.py
@@ -76,7 +76,7 @@ if DPF_SERVER_CONTEXT_ENV in os.environ.keys():
     default_context = os.getenv(DPF_SERVER_CONTEXT_ENV)
     try:
         SERVER_CONTEXT = getattr(AvailableServerContexts, default_context.lower())
-    except AttributeError:  # pragma: no cover
+    except AttributeError:
         warnings.warn(UserWarning(
                       f"{DPF_SERVER_CONTEXT_ENV} is set to {default_context}, which is not "
                       f"recognized as an available DPF ServerContext type. \n"

--- a/ansys/dpf/core/server_context.py
+++ b/ansys/dpf/core/server_context.py
@@ -4,7 +4,13 @@ ServerContext
 
 Gives the ability to choose the context with which the server should be started.
 The context allows to choose which capabilities are available.
+By default, an **Entry** type of :class:`ServerContext` is used.
+The default context can be overwritten using the ANSYS_DPF_SERVER_CONTEXT environment
+variable.
+ANSYS_DPF_SERVER_CONTEXT=ENTRY and ANSYS_DPF_SERVER_CONTEXT=PREMIUM can be used.
 """
+import os
+import warnings
 from enum import Enum
 
 
@@ -63,7 +69,20 @@ class AvailableServerContexts:
     """Loads the minimum number of plugins for a basic usage. Is the default."""
 
 
+DPF_SERVER_CONTEXT_ENV = "ANSYS_DPF_SERVER_CONTEXT"
+
 SERVER_CONTEXT = AvailableServerContexts.entry
+if DPF_SERVER_CONTEXT_ENV in os.environ.keys():
+    default_context = os.getenv(DPF_SERVER_CONTEXT_ENV)
+    try:
+        SERVER_CONTEXT = getattr(AvailableServerContexts, default_context.lower())
+    except AttributeError:  # pragma: no cover
+        warnings.warn(UserWarning(
+                      f"{DPF_SERVER_CONTEXT_ENV} is set to {default_context}, which is not "
+                      f"recognized as an available DPF ServerContext type. \n"
+                      f"Accepted values are: {[t.name.upper() for t in EContextType]}.\n"
+                      f"Using {EContextType.entry.name.upper()} "
+                      f"as the default ServerContext type."))
 
 
 def apply_server_context(context=AvailableServerContexts.entry, server=None) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -503,7 +503,6 @@ def test_context_environment_variable(reset_context_environment_variable):
         assert s_c.SERVER_CONTEXT == getattr(s_c.AvailableServerContexts, context.name)
 
 
-
 @pytest.mark.order(1)
 @pytest.mark.skipif(running_docker or not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0,
                     reason="AWP ROOT is not set with Docker")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -461,12 +461,11 @@ def set_context_back_to_premium(request):
     request.addfinalizer(revert)
 
 
-@pytest.mark.skipif(running_docker or not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0,
-                    reason="AWP ROOT is not set with Docker")
-@conftest.raises_for_servers_version_under("6.0")
-def test_context_environment_variable(set_context_back_to_premium):
-    from importlib import reload
+@pytest.fixture(autouse=False, scope="function")
+def reset_context_environment_variable(request):
+    """Reset ANSYS_DPF_SERVER_CONTEXT."""
     from ansys.dpf.core import server_context as s_c
+
     environment = os.environ
     key = s_c.DPF_SERVER_CONTEXT_ENV
     if key in environment.keys():
@@ -474,25 +473,35 @@ def test_context_environment_variable(set_context_back_to_premium):
     else:
         init_context = None
 
-    try:
-        # Test raise on wrong value
-        os.environ[key] = "PREM"
-        with pytest.warns(UserWarning, match="which is not recognized as an available "
-                                             "DPF ServerContext type."):
-            reload(s_c)
-        assert s_c.SERVER_CONTEXT == s_c.AvailableServerContexts.entry
+    def revert():
+        if init_context:
+            os.environ[key] = init_context
 
-        # Test each possible value is correctly understood and sets SERVER_CONTEXT
-        for context in s_c.EContextType:
-            os.environ[key] = context.name.upper()
-            reload(s_c)
-            assert s_c.SERVER_CONTEXT == getattr(s_c.AvailableServerContexts, context.name)
+    request.addfinalizer(revert)
 
-    except Exception as e:
-        pass
 
-    if init_context:
-        os.environ[key] = init_context
+@pytest.mark.skipif(running_docker or not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0,
+                    reason="AWP ROOT is not set with Docker")
+@conftest.raises_for_servers_version_under("6.0")
+def test_context_environment_variable(reset_context_environment_variable):
+    from importlib import reload
+    from ansys.dpf.core import server_context as s_c
+
+    key = s_c.DPF_SERVER_CONTEXT_ENV
+
+    # Test raise on wrong value
+    os.environ[key] = "PREM"
+    with pytest.warns(UserWarning, match="which is not recognized as an available "
+                                         "DPF ServerContext type."):
+        reload(s_c)
+    assert s_c.SERVER_CONTEXT == s_c.AvailableServerContexts.entry
+
+    # Test each possible value is correctly understood and sets SERVER_CONTEXT
+    for context in s_c.EContextType:
+        os.environ[key] = context.name.upper()
+        reload(s_c)
+        assert s_c.SERVER_CONTEXT == getattr(s_c.AvailableServerContexts, context.name)
+
 
 
 @pytest.mark.order(1)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -461,6 +461,40 @@ def set_context_back_to_premium(request):
     request.addfinalizer(revert)
 
 
+@pytest.mark.skipif(running_docker or not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0,
+                    reason="AWP ROOT is not set with Docker")
+@conftest.raises_for_servers_version_under("6.0")
+def test_context_environment_variable(set_context_back_to_premium):
+    from importlib import reload
+    from ansys.dpf.core import server_context as s_c
+    environment = os.environ
+    key = s_c.DPF_SERVER_CONTEXT_ENV
+    if key in environment.keys():
+        init_context = environment[key]
+    else:
+        init_context = None
+
+    try:
+        # Test raise on wrong value
+        os.environ[key] = "PREM"
+        with pytest.warns(UserWarning, match="which is not recognized as an available "
+                                             "DPF ServerContext type."):
+            reload(s_c)
+        assert s_c.SERVER_CONTEXT == s_c.AvailableServerContexts.entry
+
+        # Test each possible value is correctly understood and sets SERVER_CONTEXT
+        for context in s_c.EContextType:
+            os.environ[key] = context.name.upper()
+            reload(s_c)
+            assert s_c.SERVER_CONTEXT == getattr(s_c.AvailableServerContexts, context.name)
+
+    except Exception as e:
+        pass
+
+    if init_context:
+        os.environ[key] = init_context
+
+
 @pytest.mark.order(1)
 @pytest.mark.skipif(running_docker or not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0,
                     reason="AWP ROOT is not set with Docker")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -500,7 +500,11 @@ def test_context_environment_variable(reset_context_environment_variable):
     for context in s_c.EContextType:
         os.environ[key] = context.name.upper()
         reload(s_c)
-        assert s_c.SERVER_CONTEXT == getattr(s_c.AvailableServerContexts, context.name)
+        try:
+            assert s_c.SERVER_CONTEXT == getattr(s_c.AvailableServerContexts, context.name)
+        except AttributeError:
+            continue
+
 
 
 @pytest.mark.order(1)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -506,7 +506,6 @@ def test_context_environment_variable(reset_context_environment_variable):
             continue
 
 
-
 @pytest.mark.order(1)
 @pytest.mark.skipif(running_docker or not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0,
                     reason="AWP ROOT is not set with Docker")


### PR DESCRIPTION
Enable usage of an environment variable to set the default ServerContextType.