### PR TITLE
Ask for Ansys version in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -54,6 +54,20 @@ body:
        - 'Linux'
     validations:
       required: true
+   
+  - type: dropdown
+    id: dpf-server-version
+    attributes:
+      label: Which Ansys version are you using?
+      multiple: false
+      options:
+       - 'Ansys 2023 R1'
+       - 'Ansys 2022 R2'
+       - 'Ansys 2022 R1'
+       - 'Ansys 2021 R2'
+       - 'Ansys 2021 R1'
+    validations:
+      required: true
 
   - type: dropdown
     id: python-version
@@ -73,7 +87,7 @@ body:
     id: installed-packages
     attributes:
       label: Installed packages
-      description: Run `python -m pip freeze` to list installed packages
-      placeholder: Paste the output of `python -m pip freeze` here
+      description: Run `python -m pip list` to list installed packages
+      placeholder: Paste the output of `python -m pip list` here
     validations:
       required: true


### PR DESCRIPTION
One critical information which was not in the bug issue template is the Ansys installation version being used to run DPF.