### PR TITLE
Remove concurrency on CI when not a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
With the automatic run of the CI workflow from an external repository, this comes into conflict with usual workflow runs on master. Concurrency between these runs should be removed.

github.run_id is unique to each run, meaning if not from a PR (with pull_request.number), there will be no concurrency.

Signed-off-by: paul.profizi <paul.profizi@ansys.com>