### PR TITLE
When starting DPF with PyPIM, don't force the usage of a specific version

### DIFF
--- a/ansys/dpf/core/server_types.py
+++ b/ansys/dpf/core/server_types.py
@@ -269,10 +269,11 @@ def launch_remote_dpf(version=None):
         raise ImportError("Launching a remote session of DPF requires the installation"
                           + " of ansys-platform-instancemanagement") from e
     pim = pypim.connect()
-    
+
     # Possible improvement:
-    # When the version is not specified, it would be possible to use pim.list_definition(product_name="dpf")
-    # and select a version compatible with the current pydpf version, following the compatibility rules
+    # When the version is not specified, it would be possible to use
+    # pim.list_definition(product_name="dpf") and select a version compatible with the current
+    # pydpf version, following the compatibility rules
     instance = pim.create_instance(product_name="dpf", product_version=version)
     instance.wait_for_ready()
     grpc_service = instance.services["grpc"]

--- a/ansys/dpf/core/server_types.py
+++ b/ansys/dpf/core/server_types.py
@@ -268,8 +268,11 @@ def launch_remote_dpf(version=None):
     except ImportError as e:
         raise ImportError("Launching a remote session of DPF requires the installation"
                           + " of ansys-platform-instancemanagement") from e
-    version = version or __ansys_version__
     pim = pypim.connect()
+    
+    # Possible improvement:
+    # When the version is not specified, it would be possible to use pim.list_definition(product_name="dpf")
+    # and select a version compatible with the current pydpf version, following the compatibility rules
     instance = pim.create_instance(product_name="dpf", product_version=version)
     instance.wait_for_ready()
     grpc_service = instance.services["grpc"]

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -6,7 +6,6 @@ import grpc
 import pytest
 
 from ansys.dpf.core import server_types
-from ansys.dpf.core.misc import __ansys_version__
 from ansys.dpf.core.server_factory import ServerFactory
 from conftest import running_docker
 

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -54,7 +54,7 @@ def test_start_remote(monkeypatch):
 
     # It created a remote instance through PyPIM
     mock_client.create_instance.assert_called_with(
-        product_name="dpf", product_version=__ansys_version__
+        product_name="dpf", product_version=None
     )
 
     # It waited for this instance to be ready


### PR DESCRIPTION
The current implementation would fallback on the current `__ansys_version__` if no specific version was requested. However, PyDPF is compatible with multiple DPF version, artificially creating incompatibility.

This PR changes this behavior so that by default, no specific version is requested.
