### PR TITLE
DPF Server: default server config issue 

### DIFF
--- a/ansys/dpf/core/server_factory.py
+++ b/ansys/dpf/core/server_factory.py
@@ -578,8 +578,9 @@ class ServerFactory:
         if config is None:
             # If no SERVER_CONFIGURATION is yet defined, set one with default values
             is_server_old = False
-            if not "ansys_dpf_server" in ansys_path:
-                is_server_old = _find_outdated_ansys_version(ansys_path)
+            if ansys_path is not None:
+                if not "ansys_dpf_server" in ansys_path:
+                    is_server_old = _find_outdated_ansys_version(ansys_path)
             config = get_default_server_config(is_server_old, docker_config)
         if config.protocol == CommunicationProtocols.gRPC and config.legacy:
             return LegacyGrpcServer

--- a/ansys/dpf/core/server_factory.py
+++ b/ansys/dpf/core/server_factory.py
@@ -575,7 +575,7 @@ class ServerFactory:
         )
 
         # dpf.core.SERVER_CONFIGURATION is required to know what type of connection to set
-        if config is None:
+        if config is None: 
             # If no SERVER_CONFIGURATION is yet defined, set one with default values
             is_server_old = False
             if not "ansys_dpf_server" in ansys_path:

--- a/ansys/dpf/core/server_factory.py
+++ b/ansys/dpf/core/server_factory.py
@@ -575,7 +575,7 @@ class ServerFactory:
         )
 
         # dpf.core.SERVER_CONFIGURATION is required to know what type of connection to set
-        if config is None: 
+        if config is None:
             # If no SERVER_CONFIGURATION is yet defined, set one with default values
             is_server_old = False
             if not "ansys_dpf_server" in ansys_path:

--- a/ansys/dpf/core/server_factory.py
+++ b/ansys/dpf/core/server_factory.py
@@ -577,7 +577,9 @@ class ServerFactory:
         # dpf.core.SERVER_CONFIGURATION is required to know what type of connection to set
         if config is None:
             # If no SERVER_CONFIGURATION is yet defined, set one with default values
-            is_server_old = _find_outdated_ansys_version(ansys_path)
+            is_server_old = False
+            if not "ansys_dpf_server" in ansys_path:
+                is_server_old = _find_outdated_ansys_version(ansys_path)
             config = get_default_server_config(is_server_old, docker_config)
         if config.protocol == CommunicationProtocols.gRPC and config.legacy:
             return LegacyGrpcServer


### PR DESCRIPTION
If ansys_dpf_server_win_v2023.2.pre0 is used and this is contained in the server folder name, v202 is parsed as Ansys version and GrpcLegacyServer is the default. This prevents this behavior to have InProcessServer instead. 