### PR TITLE
Packaging update requires a fix in server_to_ansys_grpc_dpf_version

### DIFF
--- a/ansys/dpf/core/_version.py
+++ b/ansys/dpf/core/_version.py
@@ -12,7 +12,7 @@ server_to_ansys_grpc_dpf_version = {
     "3.0": ">=0.4.0",
     "4.0": ">=0.5.0",
     "5.0": ">=0.6.0",
-    "6.0": ">=0.7.*",
+    "6.0": ">=0.7dev",
 }
 
 server_to_ansys_version = {


### PR DESCRIPTION
Packaging released 22.0 and 0.7.* is not considered as a valid version anymore. 

```
Traceback (most recent call last):
  File "D:\a\pydpf-core\pydpf-core\.ci\..\examples\00-basic\11-server_types.py", line 44, in <module>
    legacy_grpc_server = dpf.start_local_server(config=legacy_grpc_config)
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\ansys\dpf\core\server.py", line 230, in start_local_server
    server = server_type(
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\ansys\dpf\core\server_types.py", line 993, in __init__
    check_ansys_grpc_dpf_version(self, timeout)
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\ansys\dpf\core\server_types.py", line 334, in check_ansys_grpc_dpf_version
    if not _compare_ansys_grpc_dpf_version(right_grpc_module_version, grpc_module_version):
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\ansys\dpf\core\server_types.py", line 298, in _compare_ansys_grpc_dpf_version
    return parse_version(grpc_module_version) >= parse_version(right_version_numbers)
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\packaging\version.py", line 52, in parse
    return Version(version)
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\packaging\version.py", line 197, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
packaging.version.InvalidVersion: Invalid version: '0.7.*'
```

It only affects LegacyGrpcServer. 
0.7.* can be replaced by 0.7dev, to ensure we consider all the 0.7.X.devX pre-release versions of ansys-grpc-dpf package. 
Here is the testing that has been done for validation:

-----------------------

With packaging==22.0

```
>>> from packaging.version import parse as parse_version
>>> l = [parse_version("0.7"),parse_version("0.7dev"),parse_version("0.7.0"),parse_version("0.7.b0"),parse_version("0.7.b1"),parse_version("0.7.0b1"),parse_version("0.7.0dev0"),parse_version("0.7.1dev0"),parse_version("0.7.dev0"),parse_version("0.7.1b0")]
>>> l
[<Version('0.7')>, <Version('0.7.dev0')>, <Version('0.7.0')>, <Version('0.7b0')>, <Version('0.7b1')>, <Version('0.7.0b1')>, <Version('0.7.0.dev0')>, <Version('0.7.1.dev0')>, <Version('0.7.dev0')>, <Version('0.7.1b0')>]
>>> l.sort()
>>> l
[<Version('0.7.dev0')>, <Version('0.7.0.dev0')>, <Version('0.7.dev0')>, <Version('0.7b0')>, <Version('0.7b1')>, <Version('0.7.0b1')>, <Version('0.7')>, <Version('0.7.0')>, <Version('0.7.1.dev0')>, <Version('0.7.1b0')>]
>>> parse_version("0.6.9") <= parse_version("0.7dev")
True
```

With packaging==21.3

```
>>> from packaging.version import parse as parse_version
>>> parse_version("0.7.*") <= parse_version("0.7dev")
True

>>> l = [parse_version("0.7"),parse_version("0.7dev"),parse_version("0.7.0"),parse_version("0.7.b0"),parse_version("0.7.b1"),parse_version("0.7.0b1"),parse_version("0.7.0dev0"),parse_version("0.7.1dev0"),parse_version("0.7.dev0"),parse_version("0.7.1b0")]
>>> l
[<Version('0.7')>, <Version('0.7.dev0')>, <Version('0.7.0')>, <Version('0.7b0')>, <Version('0.7b1')>, <Version('0.7.0b1')>, <Version('0.7.0.dev0')>, <Version('0.7.1.dev0')>, <Version('0.7.dev0')>, <Version('0.7.1b0')>]
>>> l.sort()
>>> l
[<Version('0.7.dev0')>, <Version('0.7.0.dev0')>, <Version('0.7.dev0')>, <Version('0.7b0')>, <Version('0.7b1')>, <Version('0.7.0b1')>, <Version('0.7')>, <Version('0.7.0')>, <Version('0.7.1.dev0')>, <Version('0.7.1b0')>]

```