### PR TITLE
FIX: doc-deploy-dev trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
   upload-development-docs:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'master')
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: [docs]
     steps:
       - name: "Upload development documentation"


### PR DESCRIPTION
It looks like the development documentation has not been triggering, see https://github.com/pyansys/pydpf-core/actions/runs/3731763945.

Changing here the conditional. Do you have any clues on why this may be happening, @PProfizi?