### PR TITLE
Improve plot method of the geometries

### DIFF
--- a/examples/05-plotting/07-plot_on_geometries.py
+++ b/examples/05-plotting/07-plot_on_geometries.py
@@ -36,6 +36,17 @@ model = dpf.Model(examples.find_static_rst())
 print(model)
 
 ###############################################################################
+# Load model's mesh and define camera position
+# (obtained with ``cpos=pl.show_figure(return_cpos=True)``). This will be used
+# later for plotting.
+mesh = model.metadata.meshed_region
+cpos = [
+    (0.07635352356975698, 0.1200500294271993, 0.041072502929096165),
+    (0.015, 0.045, 0.015),
+    (-0.16771051558419411, -0.1983722658245161, 0.9656715938216944),
+]
+
+###############################################################################
 # Create points, line and plane objects
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Create 8 points in the corners and one in the middle:
@@ -54,8 +65,16 @@ points = Points(
 )
 
 ###############################################################################
+# Show points together with the mesh
+points.plot(mesh, cpos=cpos)
+
+###############################################################################
 # Create line passing through the geometry's diagional:
 line = Line([[0.03, 0.03, 0.05], [0.0, 0.06, 0.0]], n_points=50)
+
+###############################################################################
+# Show line with the 3D mesh
+line.plot(mesh, cpos=cpos)
 
 ###############################################################################
 # Create vertical plane passing through the mid point:
@@ -69,11 +88,14 @@ plane = Plane(
 )
 
 ###############################################################################
+# Show plane with the 3D mesh
+plane.plot(mesh, cpos=cpos)
+
+###############################################################################
 # Map displacement field to geometry objects
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Get displacement field and model's mesh:
+# Get displacement field from model:
 disp = model.results.displacement
-mesh = model.metadata.meshed_region
 
 ###############################################################################
 # Map displacement to points in Points object:
@@ -109,15 +131,8 @@ fields_mapped = mapping_operator.outputs.fields_container()
 field_plane = fields_mapped[0]
 
 ###############################################################################
-# Plotting displacement field
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Define camera position (obtained with ``cpos=pl.show_figure(return_cpos=True)``):
-cpos = [
-    (0.07635352356975698, 0.1200500294271993, 0.041072502929096165),
-    (0.015, 0.045, 0.015),
-    (-0.16771051558419411, -0.1983722658245161, 0.9656715938216944),
-]
-###############################################################################
+# Plotting displacement field on the geometry objects
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # 3D plot of Points and display mesh:
 pl = DpfPlotter()
 pl.add_field(field_points, render_points_as_spheres=True, point_size=10)

--- a/src/ansys/dpf/core/geometry.py
+++ b/src/ansys/dpf/core/geometry.py
@@ -87,11 +87,16 @@ class Points:
         """Dimension of the Points object space."""
         return 3
 
-    def plot(self, **kwargs):
-        """Visualize Points object."""
+    def plot(self, mesh=None, **kwargs):
+        """Visualize Points object. If provided, ``mesh`` will be also plotted."""
+        cpos = kwargs.pop("cpos", None)
         pl = DpfPlotter(**kwargs)
-        pl.add_points(self._coordinates.data)
-        pl.show_figure(show_axes=True)
+        pl.add_points(
+            self._coordinates.data, render_points_as_spheres=True, point_size=10
+        )
+        if mesh:
+            pl.add_mesh(mesh, style="surface", show_edges=True, color="w", opacity=0.3)
+        pl.show_figure(show_axes=True, cpos=cpos)
 
 
 class Line:
@@ -211,20 +216,24 @@ class Line:
         ]
         return diff / np.linalg.norm(diff)
 
-    def plot(self, **kwargs):
-        """Visualize line."""
-        # Check if line is along the [1, 1, 1] direction to change camera position
-        if np.isclose(
-            np.abs(self.direction), normalize_vector(np.array([1, 1, 1]))
-        ).all():
-            camera_position = "xy"
-        else:
-            camera_position = None
+    def plot(self, mesh=None, **kwargs):
+        """Visualize line. If provided, ``mesh`` will be also plotted."""
+        cpos = kwargs.pop("cpos", None)
+        if not cpos:
+            # Check if line is along the [1, 1, 1] direction to change camera position
+            if np.isclose(
+                np.abs(self.direction), normalize_vector(np.array([1, 1, 1]))
+            ).all():
+                cpos = "xy"
+            else:
+                cpos = None
 
         # Plot line object
         pl = DpfPlotter(**kwargs)
-        pl.add_line(self._coordinates.data)
-        pl.show_figure(show_axes=True, cpos=camera_position)
+        pl.add_line(self._coordinates.data, width=5)
+        if mesh:
+            pl.add_mesh(mesh, style="surface", show_edges=True, color="w", opacity=0.3)
+        pl.show_figure(show_axes=True, cpos=cpos)
 
 
 class Plane:
@@ -414,22 +423,26 @@ class Plane:
         direction = [x - y for x, y in zip(vect[1], vect[0])]
         return normalize_vector(direction)
 
-    def plot(self, **kwargs):
-        """Visualize plane object."""
-        # Check if normal is in [1, -1, 0] direction to change camera position
-        no_vision_normal = normalize_vector(np.array([1, -1, 0]))
-        if (
-            np.isclose(self.normal_dir, no_vision_normal).all()
-            or np.isclose(self.normal_dir, -no_vision_normal).all()
-        ):
-            camera_position = "xz"
-        else:
-            camera_position = None
+    def plot(self, mesh=None, **kwargs):
+        """Visualize plane object. If provided, ``mesh`` will be also plotted."""
+        cpos = kwargs.pop("cpos", None)
+        if not cpos:
+            # Check if normal is in [1, -1, 0] direction to change camera position
+            no_vision_normal = normalize_vector(np.array([1, -1, 0]))
+            if (
+                np.isclose(self.normal_dir, no_vision_normal).all()
+                or np.isclose(self.normal_dir, -no_vision_normal).all()
+            ):
+                cpos = "xz"
+            else:
+                cpos = None
 
         # Plot plane object
         pl = DpfPlotter(**kwargs)
         pl.add_plane(self)
-        pl.show_figure(show_axes=True, cpos=camera_position)
+        if mesh:
+            pl.add_mesh(mesh, style="surface", show_edges=True, color="w", opacity=0.3)
+        pl.show_figure(show_axes=True, cpos=cpos)
 
 
 def get_plane_local_axis(normal_dir):

--- a/src/ansys/dpf/core/plotter.py
+++ b/src/ansys/dpf/core/plotter.py
@@ -87,25 +87,25 @@ class _PyVistaPlotter:
             **kwargs_in,
         )
 
-    def add_points(self, points, field):
+    def add_points(self, points, field, **kwargs):
         import pyvista as pv
 
         point_cloud = pv.PolyData(points)
         if field:
             point_cloud[f"{field.name}"] = field.data
-        self._plotter.add_points(point_cloud)
+        self._plotter.add_points(point_cloud, **kwargs)
 
-    def add_line(self, points, field=None):
+    def add_line(self, points, field=None, **kwargs):
         import pyvista as pv
 
         line_field = pv.PolyData(np.array(points))
         if field:
             line_field[f"{field.name}"] = field.data
-            self._plotter.add_mesh(line_field)
+            self._plotter.add_mesh(line_field, **kwargs)
         else:
-            self._plotter.add_lines(points)
+            self._plotter.add_lines(points, **kwargs)
 
-    def add_plane(self, plane, field=None):
+    def add_plane(self, plane, field=None, **kwargs):
         import pyvista as pv
 
         plane_plot = pv.Plane(
@@ -118,7 +118,7 @@ class _PyVistaPlotter:
         )
         if field:
             plane[f"{field.name}"] = field.data
-        self._plotter.add_mesh(plane_plot)
+        self._plotter.add_mesh(plane_plot, **kwargs)
 
     def add_mesh(self, meshed_region, deform_by=None, scale_factor=1.0, **kwargs):
 
@@ -430,14 +430,14 @@ class DpfPlotter:
             )
         )
 
-    def add_points(self, points, field=None):
-        self._internal_plotter.add_points(points, field)
+    def add_points(self, points, field=None, **kwargs):
+        self._internal_plotter.add_points(points, field, **kwargs)
 
-    def add_line(self, points, field=None):
-        self._internal_plotter.add_line(points, field)
+    def add_line(self, points, field=None, **kwargs):
+        self._internal_plotter.add_line(points, field, **kwargs)
 
-    def add_plane(self, plane, field=None):
-        self._internal_plotter.add_plane(plane, field)
+    def add_plane(self, plane, field=None, **kwargs):
+        self._internal_plotter.add_plane(plane, field, **kwargs)
 
     def add_mesh(self, meshed_region, deform_by=None, scale_factor=1.0, **kwargs):
         """Add a mesh to plot.

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -4,6 +4,7 @@ import pytest
 from ansys.dpf.core.geometry import (
     Points,
     Line,
+    Plane,
     normalize_vector,
     get_plane_local_axis,
     get_local_coords_from_global,
@@ -309,3 +310,20 @@ def test_plane_axes_and_coords_mapping(center, normal, global_ref):
         assert np.isclose(local[2], -center[np.where(normal == 1.0)[0][0]])
         glob = get_global_coords_from_local(local, axes_plane, center)
         assert np.isclose(glob, global_ref[i]).all()
+
+
+def test_plotting_with_mesh():
+    from ansys.dpf import core as dpf
+    from ansys.dpf.core import examples
+
+    model = dpf.Model(examples.find_static_rst())
+    mesh = model.metadata.meshed_region
+
+    points = Points([[0.03, 0.06, 0.03], [0.03, 0.03, 0], [0, 0, 0]])
+    points.plot(mesh)
+
+    line = Line([[0.03, 0.03, 0.05], [0.0, 0.06, 0.0]])
+    line.plot(mesh)
+
+    plane = Plane([0.015, 0.045, 0.015], [1, 1, 0])
+    plane.plot(mesh)


### PR DESCRIPTION
Fix #712.

This PR improves the plotting capabilities of the ``.plot()`` method of the geometric objects ``Points``, ``Line`` and ``Plane``.

Changes proposed:
- ``geometry.py``: accept optional argument ``mesh`` so the user can plot the geometric object together with the 3D mesh from the model. 
- ``plotter.py``: accept ``**kwargs`` as arguments so ``pyvista`` options are accepted.
- ``test_geometry.py``: add test for plotting geometries together with the mesh.
- ``07-plot_on_geometries.py``: improve example also showing how to plot the geometries together with the mesh.

This PR still has to include the changes after #714 is merged.    