### PR TITLE
Enable manual run of the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       standalone_branch_suffix:
         description: 'Suffix of the branch on standalone'
-        required: true
+        required: false
         default: ''
 
 


### PR DESCRIPTION
input standalone_branch_suffix should have required=False for it to be possible to run the CI on the regular standalone branch.