### PR TITLE
Only call doc-style (Vale) if called by a PR or a push.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: ''
+      event_name: ${{ github.event_name }}
     secrets: inherit
 
   upload-development-docs:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -63,6 +63,7 @@ jobs:
     with:
       ANSYS_VERSION: "232"
       standalone_suffix: ""
+      event_name: ${{ github.event_name }}
     secrets: inherit
 
   examples:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,7 +67,7 @@ jobs:
           echo ${{ github.event_name }}
 
   doc-style:
-    if: ${{ github.event.inputs.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'}}
+    if: ${{ github.event.inputs.event_name != 'workflow_dispatch' && github.event_name != 'workflow_dispatch' }}
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     secrets: inherit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,15 +57,6 @@ env:
   extra: "--find-links .github/"
 
 jobs:
-  debug:
-    runs-on: ubuntu-latest
-    steps:
-      - name: debug
-        shell: bash
-        run: |
-          echo ${{ github.event.inputs.event_name }}
-          echo ${{ github.event_name }}
-
   doc-style:
     if: ${{ github.event.inputs.event_name != 'workflow_dispatch' && github.event_name != 'workflow_dispatch' }}
     name: "Check doc style"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,7 @@ env:
 
 jobs:
   doc-style:
-    if: ${{ github.event_name == 'workflow_call' && github.event.inputs.event_name != 'workflow_dispatch'}}
+    if: ${{ github.event.inputs.event_name != 'workflow_dispatch' && github.event != 'workflow_call'}}
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     secrets: inherit
@@ -66,7 +66,6 @@ jobs:
   docs:
     name: "Documentation"
     runs-on: windows-latest
-    needs: [doc-style]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,8 +57,17 @@ env:
   extra: "--find-links .github/"
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: debug
+        shell: bash
+        run: |
+          echo ${{ github.event.inputs.event_name }}
+          echo ${{ github.event_name }}
+
   doc-style:
-    if: ${{ github.event.inputs.event_name != 'workflow_dispatch' && github.event != 'workflow_call'}}
+    if: ${{ github.event.inputs.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'}}
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     secrets: inherit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ''
+      event_name:
+        description: "Check style with Vale (does not work when CI is called manually)"
+        required: false
+        type: string
+        default: 'workflow_dispatch'
 # Can be called manually
   workflow_dispatch:
     inputs:
@@ -53,6 +58,7 @@ env:
 
 jobs:
   doc-style:
+    if: ${{ github.event_name == 'workflow_call' && github.event.inputs.event_name != 'workflow_dispatch'}}
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     secrets: inherit


### PR DESCRIPTION
Calls to action `errata-ai/vale-action@reviewdog` do not work if called from a workflow which was triggered manually.