### PR TITLE
Fix release pipeline, Vale style checking, and dev wheels management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: '$AWP_ROOT232/../../../dist'
+      custom-wheels: '/ansys_inc/dist/'
     secrets: inherit
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: ''
-      from_PR: ${{ github.event_name == 'pull_request' }}
+      event_name: ${{ github.event_name }}
     secrets: inherit
 
   upload-development-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       wheelhouse: false
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
+      custom-wheels: ${{ format('./dpf-standalone/v{0}/dist', inputs.ANSYS_VERSION) }}
     secrets: inherit
 
   docker_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     with:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-      custom-requirements: ''
+      custom-requirements: requirements/requirements_dev.txt
       event_name: ${{ github.event_name }}
     secrets: inherit
 
@@ -98,7 +98,7 @@ jobs:
       ANSYS_VERSION: "232"
       python_versions: '["3.8"]'
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-      custom-requirements: ''
+      custom-requirements: requirements/requirements_dev.txt
     secrets: inherit
 
   retro_231:
@@ -138,5 +138,5 @@ jobs:
     with:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-      custom-requirements: ''
+      custom-requirements: requirements/requirements_dev.txt
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       wheelhouse: false
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: ${{ format('./dpf-standalone/v{0}/dist', inputs.ANSYS_VERSION) }}
+      custom-wheels: ${{ './dpf-standalone/v232/dist' }}
     secrets: inherit
 
   docker_tests:
@@ -69,7 +69,7 @@ jobs:
     with:
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: ${{ format('./dpf-standalone/v{0}/dist', inputs.ANSYS_VERSION) }}
+      custom-wheels: ${{ './dpf-standalone/v232/dist' }}
     secrets: inherit
 
   docs:
@@ -79,7 +79,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: ${{ format('./dpf-standalone/v{0}/dist', inputs.ANSYS_VERSION) }}
+      custom-wheels: ${{ './dpf-standalone/v232/dist' }}
       event_name: ${{ github.event_name }}
     secrets: inherit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: ''
-      event_name: ${{ github.event_name }}
+      from_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
     secrets: inherit
 
   upload-development-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: '/ansys_inc/dist/'
+      custom-wheels: './dpf-standalone/dist'
     secrets: inherit
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: '../../../$AWP_ROOT232/dist'
+      custom-wheels: '$AWP_ROOT232/../../../dist'
     secrets: inherit
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: './dpf-standalone/dist'
+      custom-wheels: 'dpf-standalone/dist'
     secrets: inherit
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       wheelhouse: false
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: ${{ './dpf-standalone/v232/dist' }}
+      custom-wheels: './dpf-standalone/v232/dist'
     secrets: inherit
 
   docker_tests:
@@ -69,7 +69,7 @@ jobs:
     with:
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: ${{ './dpf-standalone/v232/dist' }}
+      custom-wheels: './dpf-standalone/v232/dist'
     secrets: inherit
 
   docs:
@@ -79,7 +79,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: ${{ './dpf-standalone/v232/dist' }}
+      custom-wheels: './dpf-standalone/v232/dist'
       event_name: ${{ github.event_name }}
     secrets: inherit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
     with:
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
+      custom-wheels: ${{ format('./dpf-standalone/v{0}/dist', inputs.ANSYS_VERSION) }}
     secrets: inherit
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: ''
-      from_PR: ${{ github.event_name == 'pull_request' && 'true' || '' }}
+      from_PR: ${{ (github.event_name == 'pull_request') && 'true' || '' }}
     secrets: inherit
 
   upload-development-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,41 +34,41 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
 
-#  style:
-#    name: "Style Check"
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: "Setup Python"
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-#
-#      - name: "Install pre-commit"
-#        run: pip install pre-commit
-#
-#      - name: "Run pre-commit"
-#        run: pre-commit run --all-files --show-diff-on-failure
-#
-#  tests:
-#    uses: ./.github/workflows/tests.yml
-#    with:
-#      ANSYS_VERSION: "232"
-#      python_versions: '["3.8"]'
-#      wheel: true
-#      wheelhouse: false
-#      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-#      custom-requirements: requirements/requirements_dev.txt
-#    secrets: inherit
-#
-#  docker_tests:
-#    name: "Build and Test on Docker"
-#    uses: ./.github/workflows/test_docker.yml
-#    with:
-#      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-#      custom-requirements: requirements/requirements_dev.txt
-#    secrets: inherit
+  style:
+    name: "Style Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Setup Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: "Install pre-commit"
+        run: pip install pre-commit
+
+      - name: "Run pre-commit"
+        run: pre-commit run --all-files --show-diff-on-failure
+
+  tests:
+    uses: ./.github/workflows/tests.yml
+    with:
+      ANSYS_VERSION: "232"
+      python_versions: '["3.8"]'
+      wheel: true
+      wheelhouse: false
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+      custom-requirements: requirements/requirements_dev.txt
+    secrets: inherit
+
+  docker_tests:
+    name: "Build and Test on Docker"
+    uses: ./.github/workflows/test_docker.yml
+    with:
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+      custom-requirements: requirements/requirements_dev.txt
+    secrets: inherit
 
   docs:
     if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
@@ -91,52 +91,52 @@ jobs:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-#  examples:
-#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-#    uses: ./.github/workflows/examples.yml
-#    with:
-#      ANSYS_VERSION: "232"
-#      python_versions: '["3.8"]'
-#      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-#      custom-requirements: ''
-#    secrets: inherit
-#
-#  retro_231:
-#    name: "retro 231"
-#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-#    uses: ./.github/workflows/tests.yml
-#    with:
-#      ANSYS_VERSION: "231"
-#      python_versions: '["3.8"]'
-#      DOCSTRING: false
-#    secrets: inherit
-#
-#  retro_222:
-#    name: "retro 222"
-#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-#    uses: ./.github/workflows/tests.yml
-#    with:
-#      ANSYS_VERSION: "222"
-#      python_versions: '["3.8"]'
-#      DOCSTRING: false
-#    secrets: inherit
-#
-#  retro_221:
-#    name: "retro 221"
-#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-#    uses: ./.github/workflows/tests.yml
-#    with:
-#      ANSYS_VERSION: "221"
-#      python_versions: '["3.8"]'
-#      DOCSTRING: false
-#    secrets: inherit
-#
-#  pydpf-post:
-#    name: "PyDPF-Post"
-#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-#    uses: ./.github/workflows/pydpf-post.yml
-#    with:
-#      ANSYS_VERSION: "232"
-#      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-#      custom-requirements: ''
-#    secrets: inherit
+  examples:
+    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+    uses: ./.github/workflows/examples.yml
+    with:
+      ANSYS_VERSION: "232"
+      python_versions: '["3.8"]'
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+      custom-requirements: ''
+    secrets: inherit
+
+  retro_231:
+    name: "retro 231"
+    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+    uses: ./.github/workflows/tests.yml
+    with:
+      ANSYS_VERSION: "231"
+      python_versions: '["3.8"]'
+      DOCSTRING: false
+    secrets: inherit
+
+  retro_222:
+    name: "retro 222"
+    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+    uses: ./.github/workflows/tests.yml
+    with:
+      ANSYS_VERSION: "222"
+      python_versions: '["3.8"]'
+      DOCSTRING: false
+    secrets: inherit
+
+  retro_221:
+    name: "retro 221"
+    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+    uses: ./.github/workflows/tests.yml
+    with:
+      ANSYS_VERSION: "221"
+      python_versions: '["3.8"]'
+      DOCSTRING: false
+    secrets: inherit
+
+  pydpf-post:
+    name: "PyDPF-Post"
+    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+    uses: ./.github/workflows/pydpf-post.yml
+    with:
+      ANSYS_VERSION: "232"
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+      custom-requirements: ''
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: ''
-      from_PR: ${{ (github.event_name == 'pull_request') && 'true' || '' }}
+      from_PR: ${{ github.event_name == 'pull_request' }}
     secrets: inherit
 
   upload-development-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
       python_versions: '["3.8"]'
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
+      custom-wheels: './dpf-standalone/v232/dist'
     secrets: inherit
 
   retro_231:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
-      custom-wheels: './dpf-standalone/v232/dist'
+      custom-wheels: '../../../$AWP_ROOT232/dist'
     secrets: inherit
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,4 +143,5 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
+      custom-wheels: './dpf-standalone/v232/dist'
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,41 +34,41 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
 
-  style:
-    name: "Style Check"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: "Setup Python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
-      - name: "Install pre-commit"
-        run: pip install pre-commit
-
-      - name: "Run pre-commit"
-        run: pre-commit run --all-files --show-diff-on-failure
-
-  tests:
-    uses: ./.github/workflows/tests.yml
-    with:
-      ANSYS_VERSION: "232"
-      python_versions: '["3.8"]'
-      wheel: true
-      wheelhouse: false
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-      custom-requirements: requirements/requirements_dev.txt
-    secrets: inherit
-
-  docker_tests:
-    name: "Build and Test on Docker"
-    uses: ./.github/workflows/test_docker.yml
-    with:
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-      custom-requirements: requirements/requirements_dev.txt
-    secrets: inherit
+#  style:
+#    name: "Style Check"
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: "Setup Python"
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+#
+#      - name: "Install pre-commit"
+#        run: pip install pre-commit
+#
+#      - name: "Run pre-commit"
+#        run: pre-commit run --all-files --show-diff-on-failure
+#
+#  tests:
+#    uses: ./.github/workflows/tests.yml
+#    with:
+#      ANSYS_VERSION: "232"
+#      python_versions: '["3.8"]'
+#      wheel: true
+#      wheelhouse: false
+#      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+#      custom-requirements: requirements/requirements_dev.txt
+#    secrets: inherit
+#
+#  docker_tests:
+#    name: "Build and Test on Docker"
+#    uses: ./.github/workflows/test_docker.yml
+#    with:
+#      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+#      custom-requirements: requirements/requirements_dev.txt
+#    secrets: inherit
 
   docs:
     if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
@@ -91,52 +91,52 @@ jobs:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  examples:
-    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-    uses: ./.github/workflows/examples.yml
-    with:
-      ANSYS_VERSION: "232"
-      python_versions: '["3.8"]'
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-      custom-requirements: ''
-    secrets: inherit
-
-  retro_231:
-    name: "retro 231"
-    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-    uses: ./.github/workflows/tests.yml
-    with:
-      ANSYS_VERSION: "231"
-      python_versions: '["3.8"]'
-      DOCSTRING: false
-    secrets: inherit
-
-  retro_222:
-    name: "retro 222"
-    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-    uses: ./.github/workflows/tests.yml
-    with:
-      ANSYS_VERSION: "222"
-      python_versions: '["3.8"]'
-      DOCSTRING: false
-    secrets: inherit
-
-  retro_221:
-    name: "retro 221"
-    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-    uses: ./.github/workflows/tests.yml
-    with:
-      ANSYS_VERSION: "221"
-      python_versions: '["3.8"]'
-      DOCSTRING: false
-    secrets: inherit
-
-  pydpf-post:
-    name: "PyDPF-Post"
-    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
-    uses: ./.github/workflows/pydpf-post.yml
-    with:
-      ANSYS_VERSION: "232"
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
-      custom-requirements: ''
-    secrets: inherit
+#  examples:
+#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+#    uses: ./.github/workflows/examples.yml
+#    with:
+#      ANSYS_VERSION: "232"
+#      python_versions: '["3.8"]'
+#      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+#      custom-requirements: ''
+#    secrets: inherit
+#
+#  retro_231:
+#    name: "retro 231"
+#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+#    uses: ./.github/workflows/tests.yml
+#    with:
+#      ANSYS_VERSION: "231"
+#      python_versions: '["3.8"]'
+#      DOCSTRING: false
+#    secrets: inherit
+#
+#  retro_222:
+#    name: "retro 222"
+#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+#    uses: ./.github/workflows/tests.yml
+#    with:
+#      ANSYS_VERSION: "222"
+#      python_versions: '["3.8"]'
+#      DOCSTRING: false
+#    secrets: inherit
+#
+#  retro_221:
+#    name: "retro 221"
+#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+#    uses: ./.github/workflows/tests.yml
+#    with:
+#      ANSYS_VERSION: "221"
+#      python_versions: '["3.8"]'
+#      DOCSTRING: false
+#    secrets: inherit
+#
+#  pydpf-post:
+#    name: "PyDPF-Post"
+#    if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
+#    uses: ./.github/workflows/pydpf-post.yml
+#    with:
+#      ANSYS_VERSION: "232"
+#      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+#      custom-requirements: ''
+#    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: ''
-      from_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+      from_PR: ${{ github.event_name == 'pull_request' && 'true' || '' }}
     secrets: inherit
 
   upload-development-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       ANSYS_VERSION: "232"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       custom-requirements: requirements/requirements_dev.txt
+      custom-wheels: ${{ format('./dpf-standalone/v{0}/dist', inputs.ANSYS_VERSION) }}
       event_name: ${{ github.event_name }}
     secrets: inherit
 

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -55,16 +55,14 @@ jobs:
       python_versions: '["3.7", "3.8", "3.9", "3.10"]'
       wheel: true
       wheelhouse: true
-      standalone_suffix: ""
-      custom-requirements: ${{ (!startsWith(github.ref, 'refs/tags/v')) && 'requirements/requirements_dev.txt' || '' }}
+      standalone_suffix: ".pre0"
     secrets: inherit
 
   docs:
     uses: ./.github/workflows/docs.yml
     with:
       ANSYS_VERSION: "232"
-      standalone_suffix: ""
-      custom-requirements: ''
+      standalone_suffix: ".pre0"
       event_name: ${{ github.event_name }}
     secrets: inherit
 
@@ -73,8 +71,7 @@ jobs:
     with:
       ANSYS_VERSION: "232"
       python_versions: '["3.7", "3.8", "3.9", "3.10"]'
-      standalone_suffix: ""
-      custom-requirements: ''
+      standalone_suffix: ".pre0"
     secrets: inherit
 
   retro_231:
@@ -109,7 +106,7 @@ jobs:
     uses: ./.github/workflows/pydpf-post.yml
     with:
       ANSYS_VERSION: "232"
-      standalone_suffix: ""
+      standalone_suffix: ".pre0"
     secrets: inherit
 
   pydpf-post_231:
@@ -137,15 +134,14 @@ jobs:
     name: "gate"
     uses: ./.github/workflows/gate.yml
     with:
-      standalone_suffix: ""
+      standalone_suffix: ".pre0"
     secrets: inherit
 
   docker_tests:
     name: "Build and Test on Docker"
     uses: ./.github/workflows/test_docker.yml
     with:
-      standalone_suffix: ""
-      custom-requirements: ${{ (!startsWith(github.ref, 'refs/tags/v')) && 'requirements/requirements_dev.txt' || '' }}
+      standalone_suffix: ".pre0"
     secrets: inherit
 
   draft_release:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -56,6 +56,7 @@ jobs:
       wheel: true
       wheelhouse: true
       standalone_suffix: ""
+      custom-requirements: requirements/requirements_dev.txt
     secrets: inherit
 
   docs:
@@ -63,6 +64,7 @@ jobs:
     with:
       ANSYS_VERSION: "232"
       standalone_suffix: ""
+      custom-requirements: ''
       event_name: ${{ github.event_name }}
     secrets: inherit
 
@@ -72,6 +74,7 @@ jobs:
       ANSYS_VERSION: "232"
       python_versions: '["3.7", "3.8", "3.9", "3.10"]'
       standalone_suffix: ""
+      custom-requirements: ''
     secrets: inherit
 
   retro_231:
@@ -142,6 +145,7 @@ jobs:
     uses: ./.github/workflows/test_docker.yml
     with:
       standalone_suffix: ""
+      custom-requirements: requirements/requirements_dev.txt
     secrets: inherit
 
   draft_release:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -56,7 +56,7 @@ jobs:
       wheel: true
       wheelhouse: true
       standalone_suffix: ""
-      custom-requirements: requirements/requirements_dev.txt
+      custom-requirements: ${{ (!startsWith(github.ref, 'refs/tags/v')) && 'requirements/requirements_dev.txt' || '' }}
     secrets: inherit
 
   docs:
@@ -145,7 +145,7 @@ jobs:
     uses: ./.github/workflows/test_docker.yml
     with:
       standalone_suffix: ""
-      custom-requirements: requirements/requirements_dev.txt
+      custom-requirements: ${{ (!startsWith(github.ref, 'refs/tags/v')) && 'requirements/requirements_dev.txt' || '' }}
     secrets: inherit
 
   draft_release:

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -4,7 +4,7 @@ name: Documentation Style Check
 on:
   workflow_call:
     inputs:
-      PR:
+      from_PR:
         description: "Whether to link Vale report to a PR check."
         required: false
         type: string
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: docs
-          reporter: ${{ github.event.inputs.PR && 'github-check' || 'local' }}
+          reporter: ${{ github.event.inputs.from_PR && 'github-check' || 'local' }}
           level: error
           filter_mode: nofilter
           fail_on_error: true

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       PR:
         description: "Whether to link Vale report to a PR check."
-        required: false
+        required: true
         type: string
         default: ''
   workflow_dispatch:

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -10,6 +10,7 @@ on:
         default: 'false'
   workflow_dispatch:
       PR:
+        description: "Whether to link Vale report to a PR check."
         required: false
         type: string
         default: 'false'

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -8,7 +8,7 @@ on:
         description: "Whether to link Vale report to a PR check."
         required: false
         type: string
-        default: 'false'
+        default: ''
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -3,17 +3,13 @@ name: Documentation Style Check
 
 on:
   workflow_call:
+    inputs:
       PR:
         description: "Whether to link Vale report to a PR check."
         required: false
         type: string
         default: 'false'
   workflow_dispatch:
-      PR:
-        description: "Whether to link Vale report to a PR check."
-        required: false
-        type: string
-        default: 'false'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -3,7 +3,7 @@ name: Documentation Style Check
 
 on:
   workflow_call:
-      from_PR:
+      PR:
         description: "Whether to link Vale report to a PR check."
         required: true
         type: string
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: docs
-          reporter: ${{ github.event.inputs.from_PR && 'github-check' || 'local' }}
+          reporter: ${{ github.event.inputs.PR && 'github-check' || 'local' }}
           level: error
           filter_mode: nofilter
           fail_on_error: true

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -11,10 +11,6 @@ on:
         default: 'false'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   docs-style:
     name: Documentation Style Check

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: docs
-          reporter: github-check
+          reporter: 'local'
           level: error
           filter_mode: nofilter
           fail_on_error: true

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -9,6 +9,10 @@ on:
         type: string
         default: 'false'
   workflow_dispatch:
+      PR:
+        required: false
+        type: string
+        default: 'false'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: docs
-          reporter: ${{ (github.event.inputs.PR == 'true') && 'github-check' || 'local' }}
+          reporter: ${{ github.event.inputs.PR && 'github-check' || 'local' }}
           level: error
           filter_mode: nofilter
           fail_on_error: true

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -4,11 +4,11 @@ name: Documentation Style Check
 on:
   workflow_call:
     inputs:
-      from_PR:
-        description: "Whether to link Vale report to a PR check."
+      vale_reporter:
+        description: "Vale reporter to use"
         required: false
         type: string
-        default: ''
+        default: 'local'
   workflow_dispatch:
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: docs
-          reporter: ${{ github.event.inputs.from_PR && 'github-check' || 'local' }}
+          reporter: ${{ inputs.vale_reporter }}
           level: error
           filter_mode: nofilter
           fail_on_error: true

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: docs
-          reporter: ${{ github.event.inputs.PR && 'github-check' || 'local' }}
+          reporter: ${{ (github.event.inputs.PR == 'true') && 'github-check' || 'local' }}
           level: error
           filter_mode: nofilter
           fail_on_error: true

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: docs
-          reporter: ${{ inputs.vale_reporter }}
+          reporter: ${{ inputs.vale_reporter || 'local' }}
           level: error
           filter_mode: nofilter
           fail_on_error: true

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -6,15 +6,10 @@ on:
     inputs:
       from_PR:
         description: "Whether to link Vale report to a PR check."
-        required: false
+        required: true
         type: string
         default: ''
   workflow_dispatch:
-      from_PR:
-        description: "Whether to link Vale report to a PR check."
-        required: false
-        type: string
-        default: ''
 
 jobs:
   docs-style:

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -10,6 +10,11 @@ on:
         type: string
         default: ''
   workflow_dispatch:
+      from_PR:
+        description: "Whether to link Vale report to a PR check."
+        required: false
+        type: string
+        default: ''
 
 jobs:
   docs-style:

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -3,6 +3,11 @@ name: Documentation Style Check
 
 on:
   workflow_call:
+      from_PR:
+        description: "Whether to link Vale report to a PR check."
+        required: true
+        type: string
+        default: 'false'
   workflow_dispatch:
 
 concurrency:
@@ -22,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: docs
-          reporter: 'local'
+          reporter: ${{ github.event.inputs.from_PR && 'github-check' || 'local' }}
           level: error
           filter_mode: nofilter
           fail_on_error: true

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
       PR:
         description: "Whether to link Vale report to a PR check."
-        required: true
+        required: false
         type: string
         default: 'false'
   workflow_dispatch:

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       PR:
         description: "Whether to link Vale report to a PR check."
-        required: true
+        required: false
         type: string
         default: ''
   workflow_dispatch:

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       from_PR:
         description: "Whether to link Vale report to a PR check."
-        required: true
+        required: false
         type: string
         default: ''
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.from_PR == 'pull_request' }}
+      PR: ${{ github.event.inputs.from_PR == 'true' }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.from_PR == 'true' }}
+      PR: ${{ github.event.inputs.from_PR == true }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,6 @@ env:
 
 jobs:
   doc-style:
-    if: ${{ github.event.inputs.event_name != 'workflow_dispatch' && github.event_name != 'workflow_dispatch' }}
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     secrets: inherit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ (github.event.inputs.from_PR == 'true') && 'true' || '' }}
+      PR: ${{ github.event.inputs.from_PR || '' }}
     secrets: inherit
 
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      from_PR: ${{ startsWith(github.event.inputs.event_name, 'pull_request') }}
+      from_PR: ${{ github.event.inputs.event_name }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,11 +50,6 @@ on:
         required: false
         type: string
         default: ''
-      from_PR:
-        description: "Whether the run request is from a PR (used for Vale)"
-        required: false
-        type: string
-        default: 'false'
 
 env:
   PACKAGE_NAME: ansys-dpf-core

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,11 @@ on:
         required: false
         type: string
         default: ''
-      event_name:
-        description: "Check style with Vale (does not work when CI is called manually)"
-        required: false
+      from_PR:
+        description: "Whether the run request is from a PR (used for Vale)"
+        required: true
         type: string
-        default: 'workflow_dispatch'
+        default: 'false'
 # Can be called manually
   workflow_dispatch:
     inputs:
@@ -60,6 +60,8 @@ jobs:
   doc-style:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
+    with:
+      from_PR: ${{ github.event.inputs.from_PR && 'true' || 'false' }}
     secrets: inherit
 
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
         default: ''
-      from_PR:
+      event_name:
         description: "Whether the run request is from a PR (used for Vale)"
         required: true
         type: string
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.from_PR == true }}
+      PR: ${{ github.event.inputs.from_PR == 'pull_request' }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,14 +57,6 @@ env:
   extra: "--find-links .github/"
 
 jobs:
-  print:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "print"
-        shell: bash
-        run: |
-          echo $GITHUB_ENV
-
   doc-style:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
@@ -72,120 +64,120 @@ jobs:
       vale_reporter: ${{ (inputs.event_name == 'pull_request') && 'github-check' || 'local' }}
     secrets: inherit
 
-#  docs:
-#    name: "Documentation"
-#    runs-on: windows-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: "Set licensing if necessary"
-#        if: inputs.ANSYS_VERSION > 231
-#        shell: bash
-#        run: |
-#          echo "ANSYS_DPF_ACCEPT_LA=Y" >> $GITHUB_ENV
-#          echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
-#          echo "ANSYS_DPF_SERVER_CONTEXT=PREMIUM" >> $GITHUB_ENV
-#
-#      - name: Setup Python
-#        uses: actions/setup-python@v4.2.0
-#        with:
-#          python-version: ${{ inputs.python_version }}
-#
-#      - name: "Build Package"
-#        id: build-package
-#        uses: pyansys/pydpf-actions/build_package@v2.3
-#        with:
-#          python-version: ${{ inputs.python_version }}
-#          ANSYS_VERSION: ${{inputs.ANSYS_VERSION}}
-#          PACKAGE_NAME: ${{env.PACKAGE_NAME}}
-#          MODULE: ${{env.MODULE}}
-#          dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
-#          install_extras: plotting
-#          wheel: false
-#          wheelhouse: false
-#          extra-pip-args: ${{ env.extra }}
-#          standalone_suffix: ${{ inputs.standalone_suffix }}
-#          custom-requirements: ${{ inputs.custom-requirements }}
-#
-#      - name: "Setup headless display"
-#        uses: pyvista/setup-headless-display-action@v1
-#
-#      - name: "Setup Graphviz"
-#        uses: ts-graphviz/setup-graphviz@v1
-#
-#      - name: "Install OS packages"
-#        run: |
-#          choco install pandoc
-#
-#      - name: "Install documentation packages for Python"
-#        run: |
-#          pip install -r requirements/requirements_docs.txt
-#
-#      - name: "Kill all servers"
-#        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
-#
-#      - name: "List installed packages"
-#        shell: bash
-#        run: pip list
-#
-#      - name: "Build HTML Documentation"
-#        shell: cmd
-#        working-directory: .ci
-#        run: |
-#          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
-#        timeout-minutes: 20
-#
-#      - name: "Check for success"
-#        shell: bash
-#        working-directory: docs
-#        run: |
-#          case `tail -n 5 log.txt | grep -F "build succeeded" >/dev/null; echo $?` in
-#          0)
-#            echo "Build succeeded!"
-#            exit 0;;
-#          1)
-#            echo "Documentation generation failed, please check previous step!"
-#            exit 1;;
-#          *)
-#            echo "An error occurred while checking success of the previous step!"
-#            exit 1;;
-#          esac
-#
-#      - name: "Kill all servers"
-#        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
-#        if: always()
-#
-#      - name: "Retrieve package version"
-#        shell: bash
-#        run: |
-#          echo "VERSION=$(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")" >> GITHUB_OUTPUT
-#          echo "${{env.PACKAGE_NAME}} version is: $(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")"
-#        id: version
-#        if: always()
-#
-#      - name: "Upload Documentation Build log"
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: doc-${{env.PACKAGE_NAME}}-log
-#          path: docs/*.txt
-#        if: always()
-#
-#      - name: "Zip HTML Documentation"
-#        uses: vimtor/action-zip@v1
-#        with:
-#          files: docs/build/html
-#          dest: HTML-doc-${{env.PACKAGE_NAME}}.zip
-#        if: always()
-#
-#      - name: "Upload HTML Documentation"
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: HTML-doc-${{env.PACKAGE_NAME}}
-#          path: HTML-doc-${{env.PACKAGE_NAME}}.zip
-#        if: always()
-#
-#      - name: "Upload HTML Documentation"
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: documentation-html
-#          path: docs/build/html
+  docs:
+    name: "Documentation"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Set licensing if necessary"
+        if: inputs.ANSYS_VERSION > 231
+        shell: bash
+        run: |
+          echo "ANSYS_DPF_ACCEPT_LA=Y" >> $GITHUB_ENV
+          echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
+          echo "ANSYS_DPF_SERVER_CONTEXT=PREMIUM" >> $GITHUB_ENV
+
+      - name: Setup Python
+        uses: actions/setup-python@v4.2.0
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: "Build Package"
+        id: build-package
+        uses: pyansys/pydpf-actions/build_package@v2.3
+        with:
+          python-version: ${{ inputs.python_version }}
+          ANSYS_VERSION: ${{inputs.ANSYS_VERSION}}
+          PACKAGE_NAME: ${{env.PACKAGE_NAME}}
+          MODULE: ${{env.MODULE}}
+          dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
+          install_extras: plotting
+          wheel: false
+          wheelhouse: false
+          extra-pip-args: ${{ env.extra }}
+          standalone_suffix: ${{ inputs.standalone_suffix }}
+          custom-requirements: ${{ inputs.custom-requirements }}
+
+      - name: "Setup headless display"
+        uses: pyvista/setup-headless-display-action@v1
+
+      - name: "Setup Graphviz"
+        uses: ts-graphviz/setup-graphviz@v1
+
+      - name: "Install OS packages"
+        run: |
+          choco install pandoc
+
+      - name: "Install documentation packages for Python"
+        run: |
+          pip install -r requirements/requirements_docs.txt
+
+      - name: "Kill all servers"
+        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+
+      - name: "List installed packages"
+        shell: bash
+        run: pip list
+
+      - name: "Build HTML Documentation"
+        shell: cmd
+        working-directory: .ci
+        run: |
+          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
+        timeout-minutes: 20
+
+      - name: "Check for success"
+        shell: bash
+        working-directory: docs
+        run: |
+          case `tail -n 5 log.txt | grep -F "build succeeded" >/dev/null; echo $?` in
+          0)
+            echo "Build succeeded!"
+            exit 0;;
+          1)
+            echo "Documentation generation failed, please check previous step!"
+            exit 1;;
+          *)
+            echo "An error occurred while checking success of the previous step!"
+            exit 1;;
+          esac
+
+      - name: "Kill all servers"
+        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+        if: always()
+
+      - name: "Retrieve package version"
+        shell: bash
+        run: |
+          echo "VERSION=$(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")" >> GITHUB_OUTPUT
+          echo "${{env.PACKAGE_NAME}} version is: $(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")"
+        id: version
+        if: always()
+
+      - name: "Upload Documentation Build log"
+        uses: actions/upload-artifact@v3
+        with:
+          name: doc-${{env.PACKAGE_NAME}}-log
+          path: docs/*.txt
+        if: always()
+
+      - name: "Zip HTML Documentation"
+        uses: vimtor/action-zip@v1
+        with:
+          files: docs/build/html
+          dest: HTML-doc-${{env.PACKAGE_NAME}}.zip
+        if: always()
+
+      - name: "Upload HTML Documentation"
+        uses: actions/upload-artifact@v3
+        with:
+          name: HTML-doc-${{env.PACKAGE_NAME}}
+          path: HTML-doc-${{env.PACKAGE_NAME}}.zip
+        if: always()
+
+      - name: "Upload HTML Documentation"
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation-html
+          path: docs/build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.event_name == 'pull_request' }}
+      PR: ${{ contains(github.event.inputs.event_name, 'pull_request') }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,14 @@ env:
   extra: "--find-links .github/"
 
 jobs:
+  print:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "print"
+        shell: bash
+        run: |
+          echo $GITHUB_ENV
+
   doc-style:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
@@ -64,120 +72,120 @@ jobs:
       PR: ${{ github.event.inputs.from_PR || '' }}
     secrets: inherit
 
-  docs:
-    name: "Documentation"
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: "Set licensing if necessary"
-        if: inputs.ANSYS_VERSION > 231
-        shell: bash
-        run: |
-          echo "ANSYS_DPF_ACCEPT_LA=Y" >> $GITHUB_ENV
-          echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
-          echo "ANSYS_DPF_SERVER_CONTEXT=PREMIUM" >> $GITHUB_ENV
-
-      - name: Setup Python
-        uses: actions/setup-python@v4.2.0
-        with:
-          python-version: ${{ inputs.python_version }}
-
-      - name: "Build Package"
-        id: build-package
-        uses: pyansys/pydpf-actions/build_package@v2.3
-        with:
-          python-version: ${{ inputs.python_version }}
-          ANSYS_VERSION: ${{inputs.ANSYS_VERSION}}
-          PACKAGE_NAME: ${{env.PACKAGE_NAME}}
-          MODULE: ${{env.MODULE}}
-          dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
-          install_extras: plotting
-          wheel: false
-          wheelhouse: false
-          extra-pip-args: ${{ env.extra }}
-          standalone_suffix: ${{ inputs.standalone_suffix }}
-          custom-requirements: ${{ inputs.custom-requirements }}
-
-      - name: "Setup headless display"
-        uses: pyvista/setup-headless-display-action@v1
-
-      - name: "Setup Graphviz"
-        uses: ts-graphviz/setup-graphviz@v1
-
-      - name: "Install OS packages"
-        run: |
-          choco install pandoc
-
-      - name: "Install documentation packages for Python"
-        run: |
-          pip install -r requirements/requirements_docs.txt
-
-      - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
-
-      - name: "List installed packages"
-        shell: bash
-        run: pip list
-
-      - name: "Build HTML Documentation"
-        shell: cmd
-        working-directory: .ci
-        run: |
-          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
-        timeout-minutes: 20
-
-      - name: "Check for success"
-        shell: bash
-        working-directory: docs
-        run: |
-          case `tail -n 5 log.txt | grep -F "build succeeded" >/dev/null; echo $?` in
-          0)
-            echo "Build succeeded!"
-            exit 0;;
-          1)
-            echo "Documentation generation failed, please check previous step!"
-            exit 1;;
-          *)
-            echo "An error occurred while checking success of the previous step!"
-            exit 1;;
-          esac
-
-      - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
-        if: always()
-
-      - name: "Retrieve package version"
-        shell: bash
-        run: |
-          echo "VERSION=$(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")" >> GITHUB_OUTPUT
-          echo "${{env.PACKAGE_NAME}} version is: $(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")"
-        id: version
-        if: always()
-
-      - name: "Upload Documentation Build log"
-        uses: actions/upload-artifact@v3
-        with:
-          name: doc-${{env.PACKAGE_NAME}}-log
-          path: docs/*.txt
-        if: always()
-
-      - name: "Zip HTML Documentation"
-        uses: vimtor/action-zip@v1
-        with:
-          files: docs/build/html
-          dest: HTML-doc-${{env.PACKAGE_NAME}}.zip
-        if: always()
-
-      - name: "Upload HTML Documentation"
-        uses: actions/upload-artifact@v3
-        with:
-          name: HTML-doc-${{env.PACKAGE_NAME}}
-          path: HTML-doc-${{env.PACKAGE_NAME}}.zip
-        if: always()
-
-      - name: "Upload HTML Documentation"
-        uses: actions/upload-artifact@v3
-        with:
-          name: documentation-html
-          path: docs/build/html
+#  docs:
+#    name: "Documentation"
+#    runs-on: windows-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: "Set licensing if necessary"
+#        if: inputs.ANSYS_VERSION > 231
+#        shell: bash
+#        run: |
+#          echo "ANSYS_DPF_ACCEPT_LA=Y" >> $GITHUB_ENV
+#          echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
+#          echo "ANSYS_DPF_SERVER_CONTEXT=PREMIUM" >> $GITHUB_ENV
+#
+#      - name: Setup Python
+#        uses: actions/setup-python@v4.2.0
+#        with:
+#          python-version: ${{ inputs.python_version }}
+#
+#      - name: "Build Package"
+#        id: build-package
+#        uses: pyansys/pydpf-actions/build_package@v2.3
+#        with:
+#          python-version: ${{ inputs.python_version }}
+#          ANSYS_VERSION: ${{inputs.ANSYS_VERSION}}
+#          PACKAGE_NAME: ${{env.PACKAGE_NAME}}
+#          MODULE: ${{env.MODULE}}
+#          dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
+#          install_extras: plotting
+#          wheel: false
+#          wheelhouse: false
+#          extra-pip-args: ${{ env.extra }}
+#          standalone_suffix: ${{ inputs.standalone_suffix }}
+#          custom-requirements: ${{ inputs.custom-requirements }}
+#
+#      - name: "Setup headless display"
+#        uses: pyvista/setup-headless-display-action@v1
+#
+#      - name: "Setup Graphviz"
+#        uses: ts-graphviz/setup-graphviz@v1
+#
+#      - name: "Install OS packages"
+#        run: |
+#          choco install pandoc
+#
+#      - name: "Install documentation packages for Python"
+#        run: |
+#          pip install -r requirements/requirements_docs.txt
+#
+#      - name: "Kill all servers"
+#        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+#
+#      - name: "List installed packages"
+#        shell: bash
+#        run: pip list
+#
+#      - name: "Build HTML Documentation"
+#        shell: cmd
+#        working-directory: .ci
+#        run: |
+#          build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
+#        timeout-minutes: 20
+#
+#      - name: "Check for success"
+#        shell: bash
+#        working-directory: docs
+#        run: |
+#          case `tail -n 5 log.txt | grep -F "build succeeded" >/dev/null; echo $?` in
+#          0)
+#            echo "Build succeeded!"
+#            exit 0;;
+#          1)
+#            echo "Documentation generation failed, please check previous step!"
+#            exit 1;;
+#          *)
+#            echo "An error occurred while checking success of the previous step!"
+#            exit 1;;
+#          esac
+#
+#      - name: "Kill all servers"
+#        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+#        if: always()
+#
+#      - name: "Retrieve package version"
+#        shell: bash
+#        run: |
+#          echo "VERSION=$(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")" >> GITHUB_OUTPUT
+#          echo "${{env.PACKAGE_NAME}} version is: $(python -c "from ansys.dpf.${{env.MODULE}} import __version__; print(__version__)")"
+#        id: version
+#        if: always()
+#
+#      - name: "Upload Documentation Build log"
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: doc-${{env.PACKAGE_NAME}}-log
+#          path: docs/*.txt
+#        if: always()
+#
+#      - name: "Zip HTML Documentation"
+#        uses: vimtor/action-zip@v1
+#        with:
+#          files: docs/build/html
+#          dest: HTML-doc-${{env.PACKAGE_NAME}}.zip
+#        if: always()
+#
+#      - name: "Upload HTML Documentation"
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: HTML-doc-${{env.PACKAGE_NAME}}
+#          path: HTML-doc-${{env.PACKAGE_NAME}}.zip
+#        if: always()
+#
+#      - name: "Upload HTML Documentation"
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: documentation-html
+#          path: docs/build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ (github.event.inputs.from_PR == true ) && 'true' || '' }}
+      PR: ${{ github.event.inputs.from_PR }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ on:
         description: "Whether the run request is from a PR (used for Vale)"
         required: true
         type: string
-        default: 'false'
+        default: ''
 # Can be called manually
   workflow_dispatch:
     inputs:
@@ -61,7 +61,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.from_PR && 'true' || 'false' }}
+      PR: ${{ github.event.inputs.from_PR && 'true' || '' }}
     secrets: inherit
 
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: string
         default: ''
+      from_PR:
+        description: "Whether the run request is from a PR (used for Vale)"
+        required: false
+        type: string
+        default: 'false'
 
 env:
   PACKAGE_NAME: ansys-dpf-core

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      from_PR: ${{ github.event_name }}
+      vale_reporter: 'github-check'
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.from_PR && 'true' || '' }}
+      PR: ${{ (github.event.inputs.from_PR == 'true') && 'true' || '' }}
     secrets: inherit
 
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      from_PR: ${{ github.event.inputs.from_PR && 'true' || 'false' }}
+      PR: ${{ github.event.inputs.from_PR && 'true' || 'false' }}
     secrets: inherit
 
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.from_PR }}
+      PR: ${{ github.event.inputs.from_PR == 'pull_request' }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,11 +50,6 @@ on:
         required: false
         type: string
         default: ''
-      event_name:
-        description: "Whether the run request is from a PR (used for Vale)"
-        required: true
-        type: string
-        default: ''
 
 env:
   PACKAGE_NAME: ansys-dpf-core
@@ -74,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      from_PR: ${{ github.event.inputs.event_name }}
+      from_PR: ${{ github.event_name }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ contains(github.event.inputs.event_name, 'pull_request') }}
+      from_PR: ${{ contains(github.event.inputs.event_name, 'pull_request') }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ on:
         type: string
         default: ''
       event_name:
-        description: "Whether the run request is from a PR (used for Vale)"
+        description: "Name of event calling"
         required: true
         type: string
         default: ''
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      vale_reporter: 'github-check'
+      vale_reporter: ${{ (inputs.event_name == 'pull_request') && 'github-check' || '' }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: string
         default: ''
+      event_name:
+        description: "Whether the run request is from a PR (used for Vale)"
+        required: true
+        type: string
+        default: ''
 
 env:
   PACKAGE_NAME: ansys-dpf-core

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ''
+      custom-wheels:
+        description: "extra pip '--find-links XXX' argument to find custom dpf wheels"
+        required: false
+        type: string
+        default: ''
       event_name:
         description: "Name of event calling"
         required: true
@@ -50,11 +55,15 @@ on:
         required: false
         type: string
         default: ''
+      custom-wheels:
+        description: "extra pip --find-links argument to find custom dpf wheels"
+        required: false
+        type: string
+        default: ''
 
 env:
   PACKAGE_NAME: ansys-dpf-core
   MODULE: core
-  extra: "--find-links .github/"
 
 jobs:
   doc-style:
@@ -95,7 +104,7 @@ jobs:
           install_extras: plotting
           wheel: false
           wheelhouse: false
-          extra-pip-args: ${{ env.extra }}
+          extra-pip-args: ${{ inputs.custom-wheels && format('--find-links {0}', inputs.custom-wheels) || '' }}
           standalone_suffix: ${{ inputs.standalone_suffix }}
           custom-requirements: ${{ inputs.custom-requirements }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.from_PR == 'pull_request' }}
+      PR: ${{ github.event.inputs.event_name == 'pull_request' }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      PR: ${{ github.event.inputs.from_PR || '' }}
+      PR: ${{ (github.event.inputs.from_PR == true ) && 'true' || '' }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      from_PR: ${{ contains(github.event.inputs.event_name, 'pull_request') }}
+      from_PR: ${{ startsWith(github.event.inputs.event_name, 'pull_request') }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     with:
-      vale_reporter: ${{ (inputs.event_name == 'pull_request') && 'github-check' || '' }}
+      vale_reporter: ${{ (inputs.event_name == 'pull_request') && 'github-check' || 'local' }}
     secrets: inherit
 
 #  docs:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ''
+      custom-wheels:
+        description: "extra pip --find-links argument to find custom dpf wheels"
+        required: false
+        type: string
+        default: ''
 # Can be called manually
   workflow_dispatch:
     inputs:
@@ -42,6 +47,11 @@ on:
         default: ''
       custom-requirements:
         description: "Path to requirements.txt file to install"
+        required: false
+        type: string
+        default: ''
+      custom-wheels:
+        description: "extra pip --find-links argument to find custom dpf wheels"
         required: false
         type: string
         default: ''
@@ -98,7 +108,7 @@ jobs:
           install_extras: plotting
           wheelhouse: false
           wheel: false
-          extra-pip-args: ${{ env.extra }}
+          extra-pip-args: ${{ inputs.custom-wheels && format('--find-links {0}', inputs.custom-wheels) || '' }}
           standalone_suffix: ${{ inputs.standalone_suffix }}
           custom-requirements: ${{ inputs.custom-requirements }}
 

--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: ''
+      custom-wheels:
+        description: "extra pip --find-links argument to find custom dpf wheels"
+        required: false
+        type: string
+        default: ''
 # Can be called manually
   workflow_dispatch:
     inputs:
@@ -43,11 +48,15 @@ on:
         required: false
         type: string
         default: ''
+      custom-wheels:
+        description: "extra pip --find-links argument to find custom dpf wheels"
+        required: false
+        type: string
+        default: ''
 
 env:
   PACKAGE_NAME: ansys-dpf-core
   MODULE: core
-  extra: "--find-links .github/"
 
 jobs:
   Clone_and_Test:
@@ -86,7 +95,7 @@ jobs:
           install_extras: plotting
           wheel: false
           wheelhouse: false
-          extra-pip-args: ${{ env.extra }}
+          extra-pip-args: ${{ inputs.custom-wheels && format('--find-links {0}', inputs.custom-wheels) || '' }}
           standalone_suffix: ${{ inputs.standalone_suffix }}
           custom-requirements: ${{ inputs.custom-requirements }}
 

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ''
+      custom-wheels:
+        description: "extra pip '--find-links XXX' argument to find custom dpf wheels"
+        required: false
+        type: string
+        default: ''
 # Can be called manually
   workflow_dispatch:
     inputs:
@@ -27,11 +32,15 @@ on:
         required: false
         type: string
         default: ''
+      custom-wheels:
+        description: "extra pip '--find-links XXX' argument to find custom dpf wheels"
+        required: false
+        type: string
+        default: ''
 
 env:
   PACKAGE_NAME: ansys-dpf-core
   MODULE: core
-  extra: "--find-links .github/"
   ANSYS_VERSION: 232
   ANSYS_DPF_ACCEPT_LA: Y
   ANSYSLMD_LICENSE_FILE: 1055@${{secrets.LICENSE_SERVER}}
@@ -59,7 +68,7 @@ jobs:
           install_extras: plotting
           wheel: false
           wheelhouse: false
-          extra-pip-args: '--find-links ./dpf-standalone/dist'
+          extra-pip-args: ${{ inputs.custom-wheels && format('--find-links {0}', inputs.custom-wheels) || '' }}
           standalone_suffix: ${{ inputs.standalone_suffix }}
           custom-requirements: ${{ inputs.custom-requirements }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: ''
+      custom-wheels:
+        description: "extra pip --find-links argument to find custom dpf wheels"
+        required: false
+        type: string
+        default: ''
 # Can be called manually
   workflow_dispatch:
     inputs:
@@ -69,6 +74,11 @@ on:
         default: ''
       custom-requirements:
         description: "Path to requirements.txt file to install"
+        required: false
+        type: string
+        default: ''
+      custom-wheels:
+        description: "extra pip --find-links argument to find custom dpf wheels"
         required: false
         type: string
         default: ''
@@ -119,7 +129,7 @@ jobs:
           install_extras: plotting
           wheel: ${{ inputs.wheel }}
           wheelhouse: ${{ inputs.wheelhouse }}
-          extra-pip-args: ${{ format('--find-links ./dpf-standalone/v{0}/dist', inputs.ANSYS_VERSION) }}
+          extra-pip-args: ${{ inputs.custom-wheels && format('--find-links {0}', inputs.custom-wheels) || '' }}
           standalone_suffix: ${{ inputs.standalone_suffix }}
           custom-requirements: ${{ inputs.custom-requirements }}
 


### PR DESCRIPTION
This PR fixes errors in the CI_release workflow seen on the weekly test on master (see https://github.com/pyansys/pydpf-core/actions/runs/3923553496)
It also improves the management of "dev wheels".

Proposed changes:
- give the event type to the docs workflow, which can then give to the doc-style workflow the correct `reporter` argument for action `errata-ai/vale-action@reviewdog` --> Vale doc style checking now works in all cases (run from CI, run manually...)
- add the `custom-wheels` argument to most reusable workflows, so we can define for each pipeline where the development wheels for `ansys-dpf-gate`, `ansys-dpf-gatebin` and `ansys-grpc-dpf` should be taken. Update `ci.yml` with this. --> Can also be given as a custom input to test wheels with manual runs.
- fix the `ci_release.yml` workflow so that is uses the latest released standalone instead of the development one. Also uses already released wheels for DPF libraries.