### PR TITLE
Fix and improve plotter.DpfPlotter behavior

### DIFF
--- a/examples/05-plotting/03-labels.py
+++ b/examples/05-plotting/03-labels.py
@@ -7,9 +7,9 @@ Add nodal labels on plots
 You can add use label properties to add custom labels to specific nodes.
 If the label for a node is not defined or `None`, the nodal scalar value
 of the currently active field at that node is shown. If no field is active,
- the node ID is shown.
+the node ID is shown.
 """
-# sphinx_gallery_thumbnail_number = 2
+
 ###############################################################################
 # Import the ``dpf_core`` module, included examples files, and the ``DpfPlotter``
 # module.
@@ -44,7 +44,14 @@ plot = DpfPlotter()
 plot.add_node_labels(
     nodes=mesh_set.nodes.scoping.ids[:5], meshed_region=mesh_set, labels=["A", "B", None, "C"]
 )
-plot.show_figure()
+plot.show_figure(
+    cpos=[
+        (0.3533494514377904, 0.312496303079723, 1.1859368974825752),
+        (-0.07891143256220956, -0.11976458092027707, 0.7536760134825755),
+        (0.0, 0.0, 1.0),
+    ]
+)
+# sphinx_gallery_thumbnail_number = 2
 
 ###############################################################################
 # Get the stress tensor and ``connect`` time scoping.

--- a/examples/05-plotting/03-labels.py
+++ b/examples/05-plotting/03-labels.py
@@ -5,9 +5,11 @@ Add nodal labels on plots
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can add use label properties to add custom labels to specific nodes.
-If label for a node is missing, the nodal scalar value is shown by default.
+If the label for a node is not defined or `None`, the nodal scalar value
+of the currently active field at that node is shown. If no field is active,
+ the node ID is shown.
 """
-
+# sphinx_gallery_thumbnail_number = 2
 ###############################################################################
 # Import the ``dpf_core`` module, included examples files, and the ``DpfPlotter``
 # module.
@@ -32,6 +34,19 @@ model = dpf.Model(examples.find_msup_transient())
 print(model)
 
 ###############################################################################
+#  Get the meshed region.
+#
+mesh_set = model.metadata.meshed_region
+
+# One can plot the mesh with labels and/or node IDs shown
+# for the first five nodes of the mesh.
+plot = DpfPlotter()
+plot.add_node_labels(
+    nodes=mesh_set.nodes.scoping.ids[:5], meshed_region=mesh_set, labels=["A", "B", None, "C"]
+)
+plot.show_figure()
+
+###############################################################################
 # Get the stress tensor and ``connect`` time scoping.
 # Make sure that you define ``"Nodal"`` as the scoping location because
 # labels are supported only for nodal results.
@@ -54,10 +69,6 @@ disp.inputs.time_scoping.connect(time_scope)
 norm_op2.inputs.connect(disp.outputs)
 field_norm_disp = norm_op2.outputs.fields_container()[0]
 print(field_norm_disp)
-###############################################################################
-#  Get the meshed region.
-#
-mesh_set = model.metadata.meshed_region
 
 ###############################################################################
 # Plot the results on the mesh and show the minimum and maximum.
@@ -74,7 +85,8 @@ plot.add_field(
 
 
 # Use label properties to add custom labels to specific nodes.
-# If a label for a node is missing, the nodal value is shown by default.
+# If a label for a node is missing and a field is active,
+# the nodal value for this field is shown.
 
 my_nodes_1 = [mesh_set.nodes[0], mesh_set.nodes[10]]
 my_labels_1 = ["MyNode1", "MyNode2"]

--- a/examples/05-plotting/03-labels.py
+++ b/examples/05-plotting/03-labels.py
@@ -42,7 +42,10 @@ mesh_set = model.metadata.meshed_region
 # for the first five nodes of the mesh.
 plot = DpfPlotter()
 plot.add_node_labels(
-    nodes=mesh_set.nodes.scoping.ids[:5], meshed_region=mesh_set, labels=["A", "B", None, "C"]
+    nodes=mesh_set.nodes.scoping.ids[:5],
+    meshed_region=mesh_set,
+    labels=["A", "B", None, "C"],
+    font_size=50,
 )
 plot.show_figure(
     cpos=[
@@ -86,7 +89,7 @@ plot.add_field(
     meshed_region=mesh_set,
     show_max=True,
     show_min=True,
-    label_text_size=15,
+    label_text_size=30,
     label_point_size=5,
 )
 

--- a/src/ansys/dpf/core/plotter.py
+++ b/src/ansys/dpf/core/plotter.py
@@ -200,11 +200,15 @@ class _PyVistaPlotter:
                     self._plotter.add_point_labels(grid_point, [labels[index]], **kwargs_in)
                 )
             else:
-                # Otherwise, get the value of the current scalar field
-                scalar_at_index = active_scalars[node_indexes[index]]
-                scalar_at_grid_point = f"{scalar_at_index:.2f}"
+                if active_scalars is not None:
+                    # get the value of the current scalar field if present
+                    scalar_at_index = active_scalars[node_indexes[index]]
+                    value = f"{scalar_at_index:.2f}"
+                else:
+                    # if no scalar field is present, print the node id
+                    value = nodes[index].id
                 label_actors.append(
-                    self._plotter.add_point_labels(grid_point, [scalar_at_grid_point], **kwargs_in)
+                    self._plotter.add_point_labels(grid_point, [value], **kwargs_in)
                 )
         return label_actors
 
@@ -408,7 +412,7 @@ class DpfPlotter:
         labels: Union[List[str], None] = None,
         **kwargs,
     ):
-        """Add labels at the nodal locations for the last added field.
+        """Add labels at nodal locations.
 
         Parameters
         ----------
@@ -417,7 +421,9 @@ class DpfPlotter:
         meshed_region:
             MeshedRegion to plot.
         labels:
-            If label for grid point is not defined, scalar value at that point is shown.
+            The labels to use. A node for which the label is not defined or `None`
+            will show the scalar value of the currently active field at that node,
+            or, if no field is active, its node ID.
         kwargs:
             Keyword arguments controlling label properties.
             See :func:`pyvista.Plotter.add_point_labels`.

--- a/src/ansys/dpf/core/plotter.py
+++ b/src/ansys/dpf/core/plotter.py
@@ -23,7 +23,7 @@ from ansys.dpf.core.common import shell_layers as eshell_layers
 from ansys.dpf.core import errors as dpf_errors
 from ansys.dpf.core.nodes import Node, Nodes
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core.meshed_region import MeshedRegion
 
 

--- a/src/ansys/dpf/core/plotter.py
+++ b/src/ansys/dpf/core/plotter.py
@@ -156,7 +156,13 @@ class _PyVistaPlotter:
         grid.set_active_scalars(None)
         self._plotter.add_mesh(grid, **kwargs_in)
 
-    def add_point_labels(self, nodes, meshed_region, labels=None, **kwargs):
+    def add_point_labels(
+        self,
+        nodes: List[Node],
+        meshed_region: MeshedRegion,
+        labels: Union[List[str], None] = None,
+        **kwargs,
+    ) -> List:
         label_actors = []
         node_indexes = [meshed_region.nodes.mapping_id_to_index.get(node.id) for node in nodes]
         grid_points = [meshed_region.grid.points[node_index] for node_index in node_indexes]
@@ -175,12 +181,15 @@ class _PyVistaPlotter:
         # The scalar data used will be the one of the last field added.
         from packaging.version import parse
 
+        active_scalars = None
         if parse(pv.__version__) >= parse("0.35.2"):
             for data_set in self._plotter._datasets:
                 if type(data_set) is pv.core.pointset.UnstructuredGrid:
                     active_scalars = data_set.active_scalars
         else:
             active_scalars = meshed_region.grid.active_scalars
+        if active_scalars is None:
+            self.add_mesh(meshed_region=meshed_region)
         # For all grid_points given
         for index, grid_point in enumerate(grid_points):
             # Check for existing label at that point
@@ -413,7 +422,6 @@ class DpfPlotter:
             Keyword arguments controlling label properties.
             See :func:`pyvista.Plotter.add_point_labels`.
         """
-        self._internal_plotter.add_mesh(meshed_region=meshed_region)
         self._labels.append(
             self._internal_plotter.add_point_labels(
                 nodes=nodes, meshed_region=meshed_region, labels=labels, **kwargs

--- a/src/ansys/dpf/core/plotter.py
+++ b/src/ansys/dpf/core/plotter.py
@@ -6,18 +6,25 @@ This module contains the DPF plotter class.
 Contains classes used to plot a mesh and a fields container using PyVista.
 """
 
+from __future__ import annotations
+
 import tempfile
 import os
 import sys
 import numpy as np
 import inspect
 import warnings
+from typing import TYPE_CHECKING, List, Union
 
 from ansys import dpf
 from ansys.dpf import core
 from ansys.dpf.core.common import locations, DefinitionLabels
 from ansys.dpf.core.common import shell_layers as eshell_layers
 from ansys.dpf.core import errors as dpf_errors
+
+if TYPE_CHECKING:
+    from ansys.dpf.core.nodes import Node
+    from ansys.dpf.core.meshed_region import MeshedRegion
 
 
 def _sort_supported_kwargs(bound_method, **kwargs):
@@ -385,21 +392,28 @@ class DpfPlotter:
         """
         return self._labels
 
-    def add_node_labels(self, nodes, meshed_region, labels=None, **kwargs):
+    def add_node_labels(
+        self,
+        nodes: List[Node],
+        meshed_region: MeshedRegion,
+        labels: Union[List[str], None] = None,
+        **kwargs,
+    ):
         """Add labels at the nodal locations for the last added field.
 
         Parameters
         ----------
-        nodes : list
+        nodes :
             Nodes where the labels should be added.
-        meshed_region: MeshedRegion
+        meshed_region:
             MeshedRegion to plot.
-        labels: : list of str or str, optional
+        labels:
             If label for grid point is not defined, scalar value at that point is shown.
-        kwargs: dict, optional
-                Keyword arguments controlling label properties.
-                See :func:`pyvista.Plotter.add_point_labels`.
+        kwargs:
+            Keyword arguments controlling label properties.
+            See :func:`pyvista.Plotter.add_point_labels`.
         """
+        self._internal_plotter.add_mesh(meshed_region=meshed_region)
         self._labels.append(
             self._internal_plotter.add_point_labels(
                 nodes=nodes, meshed_region=meshed_region, labels=labels, **kwargs
@@ -535,6 +549,12 @@ class DpfPlotter:
         >>> pl.show_figure()
 
         """
+        if "notebook" in kwargs.keys():
+            warnings.simplefilter("once")
+            warnings.warn(
+                "'notebook' is not a valid kwarg for show_figure(). "
+                "Please give this argument to the init of DpfPlotter."
+            )
         return self._internal_plotter.show_figure(**kwargs)
 
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -587,6 +587,15 @@ def test_plot_node_labels(multishells):
     assert len(a) == 2
     pl.show_figure()
 
+    pl = DpfPlotter()
+    my_labels_1 = ["MyNode1"]
+    pl.add_node_labels(
+        my_nodes_1,
+        mesh_m,
+        my_labels_1,
+    )
+    pl.show_figure()
+
 
 @pytest.mark.skipif(not HAS_PYVISTA, reason="Please install pyvista")
 def test_cpos_plot(multishells):

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -588,9 +588,9 @@ def test_plot_node_labels(multishells):
     pl.show_figure()
 
     pl = DpfPlotter()
-    my_labels_1 = ["MyNode1"]
+    my_labels_1 = ["MyNode1", None, "MyNode3"]
     pl.add_node_labels(
-        my_nodes_1,
+        mesh_m.nodes,
         mesh_m,
         my_labels_1,
     )

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -73,6 +73,13 @@ def test_plotter_on_mesh(allkindofcomplexity):
 
 
 @pytest.mark.skipif(not HAS_PYVISTA, reason="Please install pyvista")
+def test_plotter_on_mesh_warning_notebook():
+    pl = DpfPlotter()
+    with pytest.warns(expected_warning=UserWarning, match="'notebook' is not a valid kwarg"):
+        pl.show_figure(notebook=False)
+
+
+@pytest.mark.skipif(not HAS_PYVISTA, reason="Please install pyvista")
 def test_plotter_on_field(allkindofcomplexity):
     model = Model(allkindofcomplexity)
     stress = model.results.stress()


### PR DESCRIPTION
Solves #767 

DpfPlotter.add_node_labels now correctly draws the bare meshed_region given in input, with labels, in the case where no Field was added to the plotter first.
Improved typehinting and docstrings
DpfPlotter.show_figure now warns the user that the `notebook` kwarg is to be given at initialization of the DpfPlotter.