### PR TITLE
Fix operator specification unit test for next server version

### DIFF
--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1205,7 +1205,7 @@ def test_operator_specification_simple(server_type):
 
 
 def test_operator_specification_none(server_type):
-    op = dpf.core.Operator("mapdl::rst::MeshProvider", server=server_type)
+    op = dpf.core.Operator("mapdl::rst::thickness", server=server_type)
     assert op.specification.description == ""
     assert op.specification.inputs == {}
     assert op.specification.outputs == {}


### PR DESCRIPTION
The mapdl::rst::MeshProvider will have a specification on next server version -> changing used Operator