### PR TITLE
Allow for Python <4 versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-dpf-core"
 version = "0.7.3.dev0"
 description = "Data Processing Framework - Python Core "
 readme = "README.md"
-requires-python = ">=3.7, <3.11"
+requires-python = ">=3.7, <4"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "ramdane.lagha@ansys.com"},


### PR DESCRIPTION
When moving from ``pyproject.toml`` to ``setup.py``, PyDPF-Core stopped supporting Python 3.11+ versions. In your previous ``setup.py`` file, your Python limitations were ``>=3.7, <4`` and now they are ``>=3.7, <3.11``. This will cause a conflict with the PyAnsys metapackage as we can tell from: https://github.com/pyansys/pyansys-dev/issues/4

I submit this PR to replicate the previous behavior you had. I understand that this change was unintended. Consider adding a Python 3.11 smoke test in your workflow as well =)