### PR TITLE
Update build_doc.bat due to the move into src/

### DIFF
--- a/.ci/build_doc.bat
+++ b/.ci/build_doc.bat
@@ -1,10 +1,10 @@
 set SPHINX_APIDOC_OPTIONS=inherited-members
-call sphinx-apidoc -o ../docs/source/api ../ansys ../ansys/dpf/core/log.py ^
-../ansys/dpf/core/help.py ../ansys/dpf/core/mapping_types.py ../ansys/dpf/core/ipconfig.py ^
-../ansys/dpf/core/field_base.py ../ansys/dpf/core/cache.py ../ansys/dpf/core/misc.py ^
-../ansys/dpf/core/check_version.py ../ansys/dpf/core/operators/build.py ../ansys/dpf/core/operators/specification.py ^
-../ansys/dpf/core/vtk_helper.py ../ansys/dpf/core/label_space.py ../ansys/dpf/core/examples/python_plugins/* ^
-../ansys/dpf/core/examples/examples.py ^
+call sphinx-apidoc -o ../docs/source/api ../src/ansys ../src/ansys/dpf/core/log.py ^
+../src/ansys/dpf/core/help.py ../src/ansys/dpf/core/mapping_types.py ../src/ansys/dpf/core/ipconfig.py ^
+../src/ansys/dpf/core/field_base.py ../src/ansys/dpf/core/cache.py ../src/ansys/dpf/core/misc.py ^
+../src/ansys/dpf/core/check_version.py ../src/ansys/dpf/core/operators/build.py ../src/ansys/dpf/core/operators/specification.py ^
+../src/ansys/dpf/core/vtk_helper.py ../src/ansys/dpf/core/label_space.py ../src/ansys/dpf/core/examples/python_plugins/* ^
+../src/ansys/dpf/core/examples/examples.py ^
  -f --implicit-namespaces --separate  --no-headings
 pushd .
 cd ../docs/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -134,7 +134,7 @@ jobs:
         working-directory: .ci
         run: |
           build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
-        timeout-minutes: 20
+        timeout-minutes: 30
 
       - name: "Check for success"
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -134,7 +134,7 @@ jobs:
         working-directory: .ci
         run: |
           build_doc.bat > ..\docs\log.txt && type ..\docs\log.txt 2>&1
-        timeout-minutes: 30
+        timeout-minutes: 60
 
       - name: "Check for success"
         shell: bash

--- a/examples/08-averaging/01-average_across_bodies.py
+++ b/examples/08-averaging/01-average_across_bodies.py
@@ -100,7 +100,7 @@ meshes.plot(text="Body meshes")
 
 ###############################################################################
 # Workflow for not averaging across bodies
-# ---------------------------------
+# ----------------------------------------
 # Computing Von Mises stresses without averaging across the bodies of the
 # model requires the stresses to be extracted separately for each body.
 # To do this in DPF, pass a scopings container the stress operator that
@@ -176,7 +176,7 @@ def not_average_across_bodies(analysis):
 
 ###############################################################################
 # Workflow for averaging across bodies
-# -----------------------------------
+# ------------------------------------
 # The workflow for performing averaging across bodies in DPF is similar to to the
 # one shown above, with the extraction of stresses per body. The difference comes
 # in the end, where a weighted merge is done between the fields that contain different
@@ -268,7 +268,7 @@ is {:.2f}% LOWER than when it is NOT PERFORMED".format(
 
 ###############################################################################
 # Dedicated Operator
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~
 #
 # .. note::
 #     The operator detailed below is available in Ansys 23R2 and later versions.


### PR DESCRIPTION
The API documentation was no longer generated due to the `build_doc.bat` script not having been updated with the move of the sources into `src/`.

PS: the doc generation step now takes 31mn to complete...