### PR TITLE
Fix minimum version required for Unit Systems

### DIFF
--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -10,7 +10,12 @@ from ansys.dpf.core import server as server_module
 
 
 class UnitSystem:
-    """Defines an internally coherent way of measuring units."""
+    """Defines an internally coherent way of measuring units.
+
+    Notes
+    -----
+    Class available with server's version starting at 6.1 (Ansys 2023R2).
+    """
 
     def __init__(self, name, ID=None, unit_names=None):
         """
@@ -42,8 +47,8 @@ class UnitSystem:
         >>> from ansys.dpf import core as dpf
         >>> my_unit_system = dpf.UnitSystem("my_mks", unit_names="m;kg;s;degF;C;rad")
         """
-        server = server_module.get_or_create_server(dpf.SERVER)
-        if not server.meet_version("6.1"):  # pragma: no cover
+        server = server_module.get_or_create_server(None)
+        if server and not server.meet_version("6.1"):  # pragma: no cover
             raise dpf_errors.DpfVersionNotSupported("6.1")
         if not isinstance(name, str):
             raise dpf_errors.InvalidTypeError("str", "name")

--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -6,6 +6,7 @@ UnitSystem
 """
 from ansys.dpf import core as dpf
 from ansys.dpf.core import errors as dpf_errors
+from ansys.dpf.core import server as server_module
 
 
 class UnitSystem:
@@ -41,6 +42,9 @@ class UnitSystem:
         >>> from ansys.dpf import core as dpf
         >>> my_unit_system = dpf.UnitSystem("my_mks", unit_names="m;kg;s;degF;C;rad")
         """
+        server = server_module.get_or_create_server(dpf.SERVER)
+        if not server.meet_version("6.1"):  # pragma: no cover
+            raise dpf_errors.DpfVersionNotSupported("6.1")
         if not isinstance(name, str):
             raise dpf_errors.InvalidTypeError("str", "name")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,6 +210,9 @@ def cyclic_multistage():
     return core.examples.download_multi_stage_cyclic_result()
 
 
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_1 = meets_version(
+    get_server_version(core._global_server()), "6.1"
+)
 SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0 = meets_version(
     get_server_version(core._global_server()), "6.0"
 )

--- a/tests/test_lsdyna.py
+++ b/tests/test_lsdyna.py
@@ -5,8 +5,9 @@ from ansys.dpf import core as dpf
 
 
 @pytest.mark.skipif(
-    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
-    reason="LS-DYNA source operators where not supported before 0.6",
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_1,
+    reason="LS-DYNA source operators where not supported before 6.0,"
+    " and unit systems where not supported before 6.1.",
 )
 def test_lsdyna_generic(d3plot_files):
     ds = dpf.DataSources()
@@ -139,8 +140,9 @@ def test_lsdyna_generic(d3plot_files):
 
 
 @pytest.mark.skipif(
-    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
-    reason="LS-DYNA source operators where not supported before 0.6",
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_1,
+    reason="LS-DYNA source operators where not supported before 6.0,"
+    " and unit systems where not supported before 6.1.",
 )
 def test_lsdyna_beam(d3plot_beam):
     ds = dpf.DataSources()
@@ -313,8 +315,9 @@ def test_lsdyna_beam(d3plot_beam):
 
 
 @pytest.mark.skipif(
-    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
-    reason="LS-DYNA source operators where not supported before 0.6",
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_1,
+    reason="LS-DYNA source operators where not supported before 6.0,"
+    " and unit systems where not supported before 6.1.",
 )
 def test_lsdyna_matsum_rcforc(binout_matsum):
     ds = dpf.DataSources()
@@ -497,7 +500,7 @@ def test_lsdyna_matsum_rcforc(binout_matsum):
 
 @pytest.mark.skipif(
     not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
-    reason="LS-DYNA source operators where not supported before 0.6",
+    reason="LS-DYNA source operators where not supported before 6.0",
 )
 def test_lsdyna_glstat(binout_glstat):
     ds = dpf.DataSources()

--- a/tests/test_unit_systems.py
+++ b/tests/test_unit_systems.py
@@ -5,8 +5,8 @@ from ansys.dpf.core import errors as dpf_errors
 
 
 @pytest.mark.skipif(
-    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
-    reason="unit systems where not supported before 0.6",
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_1,
+    reason="Unit systems where not supported before 6.1.",
 )
 def test_predefined_unit_systems():
     # Test IDs of the predefined ones
@@ -30,8 +30,8 @@ def test_predefined_unit_systems():
 
 
 @pytest.mark.skipif(
-    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
-    reason="unit systems where not supported before 0.6",
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_1,
+    reason="Unit systems where not supported before 6.1.",
 )
 def test_unit_system_api():
     # Create custom units from ID


### PR DESCRIPTION
Unit system functionality tests was filtered as 6.0 but should be 6.1.