### PR TITLE
Add minimum DPF version logic to examples

### DIFF
--- a/.ci/run_examples.py
+++ b/.ci/run_examples.py
@@ -4,12 +4,19 @@ import pathlib
 import subprocess
 import sys
 
+import ansys.dpf.core as dpf
+
 os.environ["PYVISTA_OFF_SCREEN"] = "true"
 os.environ["MPLBACKEND"] = "Agg"
 
 actual_path = pathlib.Path(__file__).parent.absolute()
 print(os.path.join(actual_path, os.path.pardir, "examples"))
 
+# Get the DPF server version
+server = dpf.server.get_or_create_server(None)
+server_version = server.version
+server.shutdown()
+print(f"Server version: {server_version}")
 
 for root, subdirectories, files in os.walk(os.path.join(actual_path, os.path.pardir, "examples")):
     for subdirectory in subdirectories:
@@ -19,6 +26,17 @@ for root, subdirectories, files in os.walk(os.path.join(actual_path, os.path.par
                 continue
             print("\n--------------------------------------------------")
             print(file)
+            # Read the minimal server version required for the example
+            version_flag = "This example requires DPF"
+            with open(file, "r") as f:
+                for line in f:
+                    if version_flag in line:
+                        minimum_version_str = line.strip(version_flag).split[0]
+                        break
+                minimum_version_str = 0
+            if float(server_version) - float(minimum_version_str) < -0.05:
+                print(f"Example {f} skipped, requires DPF {minimum_version_str}")
+                continue
             try:
                 subprocess.check_call([sys.executable, file])
             except subprocess.CalledProcessError as e:

--- a/.ci/run_examples.py
+++ b/.ci/run_examples.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 
 import ansys.dpf.core as dpf
+from ansys.dpf.core.examples import get_example_required_minimum_dpf_version
+
 
 os.environ["PYVISTA_OFF_SCREEN"] = "true"
 os.environ["MPLBACKEND"] = "Agg"
@@ -26,14 +28,7 @@ for root, subdirectories, files in os.walk(os.path.join(actual_path, os.path.par
                 continue
             print("\n--------------------------------------------------")
             print(file)
-            # Read the minimal server version required for the example
-            version_flag = "This example requires DPF"
-            with open(file, "r") as f:
-                minimum_version_str = 0
-                for line in f:
-                    if version_flag in line:
-                        minimum_version_str = line.strip(version_flag).split()[0]
-                        break
+            minimum_version_str = get_example_required_minimum_dpf_version(file)
             if float(server_version) - float(minimum_version_str) < -0.05:
                 print(f"Example skipped as it requires DPF {minimum_version_str}.")
                 continue

--- a/.ci/run_examples.py
+++ b/.ci/run_examples.py
@@ -33,7 +33,7 @@ for root, subdirectories, files in os.walk(os.path.join(actual_path, os.path.par
                 print(f"Example skipped as it requires DPF {minimum_version_str}.")
                 continue
             try:
-                subprocess.check_output([sys.executable, file])
+                subprocess.check_call([sys.executable, file])
             except subprocess.CalledProcessError as e:
                 sys.stderr.write(str(e.args))
                 if e.returncode != 3221225477:

--- a/.ci/run_examples.py
+++ b/.ci/run_examples.py
@@ -29,16 +29,16 @@ for root, subdirectories, files in os.walk(os.path.join(actual_path, os.path.par
             # Read the minimal server version required for the example
             version_flag = "This example requires DPF"
             with open(file, "r") as f:
+                minimum_version_str = 0
                 for line in f:
                     if version_flag in line:
-                        minimum_version_str = line.strip(version_flag).split[0]
+                        minimum_version_str = line.strip(version_flag).split()[0]
                         break
-                minimum_version_str = 0
             if float(server_version) - float(minimum_version_str) < -0.05:
-                print(f"Example {f} skipped, requires DPF {minimum_version_str}")
+                print(f"Example skipped as it requires DPF {minimum_version_str}.")
                 continue
             try:
-                subprocess.check_call([sys.executable, file])
+                subprocess.check_output([sys.executable, file])
             except subprocess.CalledProcessError as e:
                 sys.stderr.write(str(e.args))
                 if e.returncode != 3221225477:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import numpy as np
 import pyvista
 from ansys.dpf.core import __version__, server, server_factory
+from ansys.dpf.core.examples import get_example_required_minimum_dpf_version
 from ansys_sphinx_theme import pyansys_logo_black, ansys_favicon, get_version_match
 
 # Manage errors
@@ -53,27 +54,9 @@ ignored_pattern = r"(ignore"
 header_flag = "\"\"\""
 note_flag = r".. note::"
 for example in glob(r"../../examples/**/*.py"):
-    version_flag = "This example requires DPF"
-    example_name = example.split(os.path.sep)[-1]
-    in_header = False
-    previous_line_is_note = False
-    with open(example, "r") as f:
-        minimum_version_str = 0
-        for line in f:
-            if line[:3] == header_flag:
-                if not in_header:
-                    in_header = True
-                    continue
-                else:
-                    break
-            if (version_flag in line) and previous_line_is_note and in_header:
-                minimum_version_str = line.strip(version_flag).split()[0]
-                break
-            if note_flag in line:
-                previous_line_is_note = True
-            else:
-                previous_line_is_note = False
+    minimum_version_str = get_example_required_minimum_dpf_version(example)
     if float(server_version) - float(minimum_version_str) < -0.05:
+        example_name = example.split(os.path.sep)[-1]
         print(f"Example {example_name} skipped as it requires DPF {minimum_version_str}.")
         ignored_pattern += f"|{example_name}"
 ignored_pattern += r")"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import numpy as np
 import pyvista
-from ansys.dpf.core import __version__, server
+from ansys.dpf.core import __version__, server, server_factory
 from ansys_sphinx_theme import pyansys_logo_black, ansys_favicon, get_version_match
 
 # Manage errors
@@ -40,30 +40,43 @@ release = __version__
 # -- Rename files to be ignored with the ignored pattern ---------------------
 
 # Get the DPF server version
-server = server.get_or_create_server(None)
-server_version = server.version
-server.shutdown()
+server_instance = server.start_local_server(
+    as_global=False,
+    config=server_factory.AvailableServerConfigs.GrpcServer,
+)
+server_version = server_instance.version
+server.shutdown_all_session_servers()
 print(f"DPF version: {server_version}")
-ignored_pattern = r""
+
+# Build ignore pattern
+ignored_pattern = r"(ignore"
+header_flag = "\"\"\""
+note_flag = r".. note::"
 for example in glob(r"../../examples/**/*.py"):
     version_flag = "This example requires DPF"
     example_name = example.split(os.path.sep)[-1]
+    in_header = False
+    previous_line_is_note = False
     with open(example, "r") as f:
         minimum_version_str = 0
         for line in f:
-            if version_flag in line:
+            if line[:3] == header_flag:
+                if not in_header:
+                    in_header = True
+                    continue
+                else:
+                    break
+            if (version_flag in line) and previous_line_is_note and in_header:
                 minimum_version_str = line.strip(version_flag).split()[0]
                 break
+            if note_flag in line:
+                previous_line_is_note = True
+            else:
+                previous_line_is_note = False
     if float(server_version) - float(minimum_version_str) < -0.05:
         print(f"Example {example_name} skipped as it requires DPF {minimum_version_str}.")
-        if ignored_pattern == "":
-            ignored_pattern += r"("
-        else:
-            ignored_pattern += "|"
-        ignored_pattern += f"{example_name}"
-
-if ignored_pattern != "":
-    ignored_pattern += r")"
+        ignored_pattern += f"|{example_name}"
+ignored_pattern += r")"
 
 # -- General configuration ---------------------------------------------------
 

--- a/examples/08-averaging/01-average_across_bodies.py
+++ b/examples/08-averaging/01-average_across_bodies.py
@@ -16,6 +16,9 @@ dealing with ``Nodal`` variables. It also illustrates how the end results
 of a postprocessing workflow can be different when averaging and when not.
 
 .. note::
+    This example requires DPF 2023.2.pre1 or above.
+
+.. note::
     This example requires the Premium Server Context.
     For more information, see :ref:`user_guide_server_context`.
 

--- a/examples/08-averaging/01-average_across_bodies.py
+++ b/examples/08-averaging/01-average_across_bodies.py
@@ -16,7 +16,8 @@ dealing with ``Nodal`` variables. It also illustrates how the end results
 of a postprocessing workflow can be different when averaging and when not.
 
 .. note::
-    This example requires DPF 2023.2.pre1 or above.
+    This example requires DPF 6.1 or above.
+    For more information, see :ref:`_ref_compatibility`.
 
 .. note::
     This example requires the Premium Server Context.

--- a/examples/08-averaging/01-average_across_bodies.py
+++ b/examples/08-averaging/01-average_across_bodies.py
@@ -17,7 +17,7 @@ of a postprocessing workflow can be different when averaging and when not.
 
 .. note::
     This example requires DPF 6.1 or above.
-    For more information, see :ref:`_ref_compatibility`.
+    For more information, see :ref:`ref_compatibility`.
 
 .. note::
     This example requires the Premium Server Context.

--- a/src/ansys/dpf/core/examples/examples.py
+++ b/src/ansys/dpf/core/examples/examples.py
@@ -33,6 +33,43 @@ simple_cyclic = os.path.join(_module_path, "file_cyclic.rst")
 distributed_msup_folder = os.path.join(_module_path, "msup_distributed")
 
 
+def get_example_required_minimum_dpf_version(file: str) -> str:
+    """Returns the minimal DPF server version required to run the example, as declared in a note.
+
+    Parameters
+    ----------
+    file:
+        Path to the example file in question.
+
+    Returns
+    -------
+    Returns the minimal DPF server version required.
+    """
+    # Read the minimal server version required for the example
+    header_flag = '"""'
+    note_flag = r".. note::"
+    version_flag = "This example requires DPF"
+    in_header = False
+    previous_line_is_note = False
+    minimum_version_str = 0
+    with open(file, "r") as f:
+        for line in f:
+            if line[:3] == header_flag:
+                if not in_header:
+                    in_header = True
+                    continue
+                else:
+                    break
+            if (version_flag in line) and previous_line_is_note and in_header:
+                minimum_version_str = line.strip(version_flag).split()[0]
+                break
+            if note_flag in line:
+                previous_line_is_note = True
+            else:
+                previous_line_is_note = False
+    return minimum_version_str
+
+
 def find_files(local_path, should_upload=True, server=None, return_local_path=False):
     """Make the result file available server side, if the server is remote the file is uploaded
     server side. Returns the path on the file.

--- a/src/ansys/dpf/core/examples/examples.py
+++ b/src/ansys/dpf/core/examples/examples.py
@@ -33,7 +33,7 @@ simple_cyclic = os.path.join(_module_path, "file_cyclic.rst")
 distributed_msup_folder = os.path.join(_module_path, "msup_distributed")
 
 
-def get_example_required_minimum_dpf_version(file: str) -> str:
+def get_example_required_minimum_dpf_version(file: os.PathLike) -> str:
     """Returns the minimal DPF server version required to run the example, as declared in a note.
 
     Parameters
@@ -51,7 +51,7 @@ def get_example_required_minimum_dpf_version(file: str) -> str:
     version_flag = "This example requires DPF"
     in_header = False
     previous_line_is_note = False
-    minimum_version_str = 0
+    minimum_version_str = "0.0"
     with open(file, "r") as f:
         for line in f:
             if line[:3] == header_flag:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -116,3 +116,39 @@ def test_license_agr(set_context_back_to_premium):
     dpf.start_local_server(config=config, as_global=True)
     assert "static" in examples.find_static_rst()
     assert dpf.Operator("stream_provider") is not None
+
+
+def test_get_example_required_minimum_dpf_version(tmp_path):
+    # Check version is parsed
+    example_header = """
+\"\"\"
+.. _ref_average_across_bodies:
+
+Average across bodies
+~~~~~~~~~~~~~~~~~~~~~
+.. note::
+    This example requires DPF 6.1 or above.
+    For more information, see :ref:`ref_compatibility`.
+\"\"\"
+    """
+    p = tmp_path / "test_example_version_0.py"
+    p.write_text(example_header)
+    assert examples.get_example_required_minimum_dpf_version(p) == "6.1"
+    # Check default version is 0.0, and versions declared outside a note in a header do not work
+    example_header = """
+\"\"\"
+.. _ref_average_across_bodies:
+
+Average across bodies
+~~~~~~~~~~~~~~~~~~~~~
+.. note::
+    This example requires Premium
+
+This example requires DPF 1.2 or above.
+\"\"\"
+This example requires DPF 2.3 or above.
+from ansys.dpf import core as dpf
+    """
+    p = tmp_path / "test_example_version_1.py"
+    p.write_text(example_header)
+    assert examples.get_example_required_minimum_dpf_version(p) == "0.0"


### PR DESCRIPTION
Managing the minimal DPF version required to run an example is necessary to be able to continue CI/CD with continuous integration of examples and features only available on the DPF server currently under development, but not yet in the one already out.
For now, this is specified with a note in the header of the example, stating for example:
 ```
.. note::
    This example requires DPF 6.1 or above.
    For more information, see :ref:`ref_compatibility`.
```
The two digits version number is used, however I think we could use the DPF Server package version if we wanted to.

See [docs](https://github.com/pyansys/pydpf-core/actions/runs/4105649624) job as well as [examples](https://github.com/pyansys/pydpf-core/actions/runs/4105653287) job for the 2023.2.pre0 server.