### PR TITLE
Add explicit dependency on 'setuptools'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "importlib-metadata >=4.0",
     "psutil",
     "packaging",
+    "setuptools",
     "tqdm",
     "numpy<1.24",
     "ansys-dpf-gate>=0.3.*",


### PR DESCRIPTION
Add an explicit dependency on `setuptools`. This is needed because the 
`pkg_resources` module is used, which is provided by `setuptools`.

Closes #784.