### PR TITLE
Allow doctest to deal with features requiring future server version

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,11 @@
 Launch or connect to a persistent local DPF service to be shared in
 pytest as a session fixture
 """
+from doctest import OutputChecker
+from unittest import mock
+
+import pytest
+
 from ansys.dpf import core
 from ansys.dpf.core.misc import module_exists
 
@@ -17,3 +22,17 @@ if module_exists("matplotlib"):
 # enable off_screen plotting to avoid test interruption
 core.settings.disable_off_screen_rendering()
 core.settings.bypass_pv_opengl_osmesa_crash()
+
+
+class DPFOutputChecker(OutputChecker):
+    def check_output(self, want: str, got: str, optionflags: int) -> bool:
+        feature_str = "Feature not supported. Upgrade the server to"
+        if feature_str in got:
+            want = got
+        return OutputChecker.check_output(self, want, got, optionflags)
+
+
+@pytest.fixture(autouse=True)
+def accept_upgrade_error():
+    with mock.patch("doctest.OutputChecker", DPFOutputChecker):
+        yield

--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -118,11 +118,14 @@ class unit_systems:
 
     """
 
-    solver_mks = UnitSystem("solver_mks", ID=11)
-    solver_cgs = UnitSystem("solver_cgs", ID=5)
-    solver_nmm = UnitSystem("solver_nmm", ID=6)
-    solver_umks = UnitSystem("solver_umks", ID=10)
-    solver_knms = UnitSystem("solver_knms", ID=16)
-    solver_bft = UnitSystem("solver_bft", ID=7)
-    solver_bin = UnitSystem("solver_bin", ID=8)
-    undefined = UnitSystem("undefined", ID=-1)
+    try:
+        solver_mks = UnitSystem("solver_mks", ID=11)
+        solver_cgs = UnitSystem("solver_cgs", ID=5)
+        solver_nmm = UnitSystem("solver_nmm", ID=6)
+        solver_umks = UnitSystem("solver_umks", ID=10)
+        solver_knms = UnitSystem("solver_knms", ID=16)
+        solver_bft = UnitSystem("solver_bft", ID=7)
+        solver_bin = UnitSystem("solver_bin", ID=8)
+        undefined = UnitSystem("undefined", ID=-1)
+    except dpf_errors.DpfVersionNotSupported as e:
+        pass

--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -48,8 +48,8 @@ class UnitSystem:
         >>> my_unit_system = dpf.UnitSystem("my_mks", unit_names="m;kg;s;degF;C;rad")
         """
         server = server_module.get_or_create_server(None)
-        if server and not server.meet_version("6.2"):  # pragma: no cover
-            raise dpf_errors.DpfVersionNotSupported("6.2")
+        if server and not server.meet_version("6.1"):  # pragma: no cover
+            raise dpf_errors.DpfVersionNotSupported("6.1")
         if not isinstance(name, str):
             raise dpf_errors.InvalidTypeError("str", "name")
 

--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -95,39 +95,34 @@ class UnitSystem:
             return self._unit_names
 
 
-try:
+class unit_systems:
+    """Contains common Ansys predefined UnitSystems.
 
-    class unit_systems:
-        """Contains common Ansys predefined UnitSystems.
+    Attributes
+    -----------
+    solver_mks : Metric (m, kg, N, s, J, Pa, degC, C, rad)
 
-        Attributes
-        -----------
-        solver_mks : Metric (m, kg, N, s, J, Pa, degC, C, rad)
+    solver_cgs : Metric (cm, g, dyne, s, erg, dyne*cm^-2, degC, C, rad)
 
-        solver_cgs : Metric (cm, g, dyne, s, erg, dyne*cm^-2, degC, C, rad)
+    solver_nmm : Metric (mm, ton, N, s, mJ, MPa, degC, mC, rad)
 
-        solver_nmm : Metric (mm, ton, N, s, mJ, MPa, degC, mC, rad)
+    solver_umks : Metric (um, kg, uN, s, pJ, MPa, degC, pC, rad)
 
-        solver_umks : Metric (um, kg, uN, s, pJ, MPa, degC, pC, rad)
+    solver_knms : Metric (mm, kg, kN, ms, J, GPa, degC, mC, rad)
 
-        solver_knms : Metric (mm, kg, kN, ms, J, GPa, degC, mC, rad)
+    solver_bft : U.S. Customary (ft, slug, lbf, s, ft*lbf, lbf*ft^-2, degF, C, rad)
 
-        solver_bft : U.S. Customary (ft, slug, lbf, s, ft*lbf, lbf*ft^-2, degF, C, rad)
+    solver_bin : U.S. Customary (in, slinch, lbf, s, in*lbf, lbf*in^-2, degF, C, rad)
 
-        solver_bin : U.S. Customary (in, slinch, lbf, s, in*lbf, lbf*in^-2, degF, C, rad)
+    undefined : All units are dimensionless
 
-        undefined : All units are dimensionless
+    """
 
-        """
-
-        solver_mks = UnitSystem("solver_mks", ID=11)
-        solver_cgs = UnitSystem("solver_cgs", ID=5)
-        solver_nmm = UnitSystem("solver_nmm", ID=6)
-        solver_umks = UnitSystem("solver_umks", ID=10)
-        solver_knms = UnitSystem("solver_knms", ID=16)
-        solver_bft = UnitSystem("solver_bft", ID=7)
-        solver_bin = UnitSystem("solver_bin", ID=8)
-        undefined = UnitSystem("undefined", ID=-1)
-
-except dpf_errors.DpfVersionNotSupported as e:
-    pass
+    solver_mks = UnitSystem("solver_mks", ID=11)
+    solver_cgs = UnitSystem("solver_cgs", ID=5)
+    solver_nmm = UnitSystem("solver_nmm", ID=6)
+    solver_umks = UnitSystem("solver_umks", ID=10)
+    solver_knms = UnitSystem("solver_knms", ID=16)
+    solver_bft = UnitSystem("solver_bft", ID=7)
+    solver_bin = UnitSystem("solver_bin", ID=8)
+    undefined = UnitSystem("undefined", ID=-1)

--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -131,5 +131,5 @@ class unit_systems:
         solver_bft = UnitSystem("solver_bft", ID=7)
         solver_bin = UnitSystem("solver_bin", ID=8)
         undefined = UnitSystem("undefined", ID=-1)
-    except dpf_errors.DpfVersionNotSupported as e:
+    except dpf_errors.DpfVersionNotSupported as e:  # pragma: no cover
         pass

--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -98,6 +98,10 @@ class UnitSystem:
 class unit_systems:
     """Contains common Ansys predefined UnitSystems.
 
+    Notes
+    -----
+    Class available with server's version starting at 6.1 (Ansys 2023R2).
+
     Attributes
     -----------
     solver_mks : Metric (m, kg, N, s, J, Pa, degC, C, rad)
@@ -118,11 +122,14 @@ class unit_systems:
 
     """
 
-    solver_mks = UnitSystem("solver_mks", ID=11)
-    solver_cgs = UnitSystem("solver_cgs", ID=5)
-    solver_nmm = UnitSystem("solver_nmm", ID=6)
-    solver_umks = UnitSystem("solver_umks", ID=10)
-    solver_knms = UnitSystem("solver_knms", ID=16)
-    solver_bft = UnitSystem("solver_bft", ID=7)
-    solver_bin = UnitSystem("solver_bin", ID=8)
-    undefined = UnitSystem("undefined", ID=-1)
+    try:
+        solver_mks = UnitSystem("solver_mks", ID=11)
+        solver_cgs = UnitSystem("solver_cgs", ID=5)
+        solver_nmm = UnitSystem("solver_nmm", ID=6)
+        solver_umks = UnitSystem("solver_umks", ID=10)
+        solver_knms = UnitSystem("solver_knms", ID=16)
+        solver_bft = UnitSystem("solver_bft", ID=7)
+        solver_bin = UnitSystem("solver_bin", ID=8)
+        undefined = UnitSystem("undefined", ID=-1)
+    except dpf_errors.DpfVersionNotSupported as e:
+        pass

--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -48,8 +48,8 @@ class UnitSystem:
         >>> my_unit_system = dpf.UnitSystem("my_mks", unit_names="m;kg;s;degF;C;rad")
         """
         server = server_module.get_or_create_server(None)
-        if server and not server.meet_version("6.1"):  # pragma: no cover
-            raise dpf_errors.DpfVersionNotSupported("6.1")
+        if server and not server.meet_version("6.2"):  # pragma: no cover
+            raise dpf_errors.DpfVersionNotSupported("6.2")
         if not isinstance(name, str):
             raise dpf_errors.InvalidTypeError("str", "name")
 
@@ -95,30 +95,31 @@ class UnitSystem:
             return self._unit_names
 
 
-class unit_systems:
-    """Contains common Ansys predefined UnitSystems.
+try:
 
-    Attributes
-    -----------
-    solver_mks : Metric (m, kg, N, s, J, Pa, degC, C, rad)
+    class unit_systems:
+        """Contains common Ansys predefined UnitSystems.
 
-    solver_cgs : Metric (cm, g, dyne, s, erg, dyne*cm^-2, degC, C, rad)
+        Attributes
+        -----------
+        solver_mks : Metric (m, kg, N, s, J, Pa, degC, C, rad)
 
-    solver_nmm : Metric (mm, ton, N, s, mJ, MPa, degC, mC, rad)
+        solver_cgs : Metric (cm, g, dyne, s, erg, dyne*cm^-2, degC, C, rad)
 
-    solver_umks : Metric (um, kg, uN, s, pJ, MPa, degC, pC, rad)
+        solver_nmm : Metric (mm, ton, N, s, mJ, MPa, degC, mC, rad)
 
-    solver_knms : Metric (mm, kg, kN, ms, J, GPa, degC, mC, rad)
+        solver_umks : Metric (um, kg, uN, s, pJ, MPa, degC, pC, rad)
 
-    solver_bft : U.S. Customary (ft, slug, lbf, s, ft*lbf, lbf*ft^-2, degF, C, rad)
+        solver_knms : Metric (mm, kg, kN, ms, J, GPa, degC, mC, rad)
 
-    solver_bin : U.S. Customary (in, slinch, lbf, s, in*lbf, lbf*in^-2, degF, C, rad)
+        solver_bft : U.S. Customary (ft, slug, lbf, s, ft*lbf, lbf*ft^-2, degF, C, rad)
 
-    undefined : All units are dimensionless
+        solver_bin : U.S. Customary (in, slinch, lbf, s, in*lbf, lbf*in^-2, degF, C, rad)
 
-    """
+        undefined : All units are dimensionless
 
-    try:
+        """
+
         solver_mks = UnitSystem("solver_mks", ID=11)
         solver_cgs = UnitSystem("solver_cgs", ID=5)
         solver_nmm = UnitSystem("solver_nmm", ID=6)
@@ -127,5 +128,6 @@ class unit_systems:
         solver_bft = UnitSystem("solver_bft", ID=7)
         solver_bin = UnitSystem("solver_bin", ID=8)
         undefined = UnitSystem("undefined", ID=-1)
-    except dpf_errors.DpfVersionNotSupported as e:
-        pass
+
+except dpf_errors.DpfVersionNotSupported as e:
+    pass


### PR DESCRIPTION
Features added to PyDPF-Core only available with the DPF server currently under development should not prevent the CI_release from running and PyDPF-Core from being able to be released anytime.
Those are marked as requiring DPF server version > XXX.
Tests are versions, examples now also deal with that, yet the docstrings examples (run through doctest) were not managed.

This PR adds a [custom doctest runner](https://docs.python.org/3/library/doctest.html#advanced-api) to detect docstring examples failing due `DpfVersionNotSupported`, and mark them as passing.
Before: https://github.com/pyansys/pydpf-core/actions/runs/4156462538/jobs/7190270043#step:8:89
After: https://github.com/pyansys/pydpf-core/actions/runs/4175995794