### PR TITLE
Update doctest for Specification.description following server-side corrections

### DIFF
--- a/src/ansys/dpf/core/operator_specification.py
+++ b/src/ansys/dpf/core/operator_specification.py
@@ -298,7 +298,7 @@ class Specification(SpecificationBase):
         >>> from ansys.dpf import core as dpf
         >>> operator = dpf.operators.math.scale_by_field()
         >>> operator.specification.description
-        "Scales a field (in 0) by a scalar field (in 1). If one field's ... the entire other field."
+        "Scales a field (in 0) by a scalar field (in 1). If one field's ..."
         """
         if self._internal_obj is not None:
             return self._api.operator_specification_get_description(self)


### PR DESCRIPTION
Following the last update of the DPF standalone, corrections to operator specifications have been made and should be propagated to PyDPF-Core.

https://github.com/pyansys/pydpf-core/actions/runs/4234502019/jobs/7356880967 tests run on the _test standalone branch.