### PR TITLE
Fix Line.__init__ for Python 3.7 with numpy 1.21.6

### DIFF
--- a/src/ansys/dpf/core/geometry.py
+++ b/src/ansys/dpf/core/geometry.py
@@ -126,7 +126,7 @@ class Line:
     def __init__(self, coordinates, n_points=100, server=None):
         """Initialize line object from two 3D points and discretize."""
         if not isinstance(coordinates, Field):
-            coordinates = np.array(coordinates, dtype=np.number)
+            coordinates = np.asarray(coordinates, dtype=np.number)
             coordinates = field_from_array(coordinates)
         if not len(coordinates.data) == 2:
             raise ValueError("Only two points must be introduced to define a line")

--- a/src/ansys/dpf/core/geometry.py
+++ b/src/ansys/dpf/core/geometry.py
@@ -126,6 +126,7 @@ class Line:
     def __init__(self, coordinates, n_points=100, server=None):
         """Initialize line object from two 3D points and discretize."""
         if not isinstance(coordinates, Field):
+            coordinates = np.array(coordinates, dtype=np.number)
             coordinates = field_from_array(coordinates)
         if not len(coordinates.data) == 2:
             raise ValueError("Only two points must be introduced to define a line")


### PR DESCRIPTION
Translate coordinates to numpy array of type np.number in Line.init when not a DPF Field.
Fixes an error here https://github.com/pyansys/pydpf-core/actions/runs/4252250685/jobs/7395598740#step:11:2539
specific to Python 3.7 which still uses Numpy 1.21.6 (latest for 3.7).