### PR TITLE
Feat/preprate 2023.2.pre1 premium default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       ANSYS_VERSION: "232"
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '_test' }}
       custom-requirements: requirements/requirements_dev.txt
       custom-wheels: './dpf-standalone/v232/dist'
       event_name: ${{ github.event_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       standalone_branch_suffix:
         description: 'Suffix of the branch on standalone'
         required: false
-        default: ''
+        default: '_test'
 
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       python_versions: '["3.8"]'
       wheel: true
       wheelhouse: false
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '_test' }}
       custom-requirements: requirements/requirements_dev.txt
       custom-wheels: './dpf-standalone/v232/dist'
     secrets: inherit
@@ -67,7 +67,7 @@ jobs:
     name: "Build and Test on Docker"
     uses: ./.github/workflows/test_docker.yml
     with:
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '_test' }}
       custom-requirements: requirements/requirements_dev.txt
       custom-wheels: 'dpf-standalone/dist'
     secrets: inherit
@@ -100,7 +100,7 @@ jobs:
     with:
       ANSYS_VERSION: "232"
       python_versions: '["3.8"]'
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '_test' }}
       custom-requirements: requirements/requirements_dev.txt
       custom-wheels: './dpf-standalone/v232/dist'
     secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ on:
         description: "Suffix of the branch on standalone"
         required: false
         type: string
-        default: '_test'
+        default: ''
       custom-requirements:
         description: "Path to requirements.txt file to install"
         required: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ on:
         description: "Suffix of the branch on standalone"
         required: false
         type: string
-        default: ''
+        default: '_test'
       custom-requirements:
         description: "Path to requirements.txt file to install"
         required: false

--- a/examples/03-harmonic_analyses/00-multi_harmonic.py
+++ b/examples/03-harmonic_analyses/00-multi_harmonic.py
@@ -20,8 +20,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Begin by downloading the example harmonic result. This result is
 # not included in the core module by default to speed up the install.

--- a/examples/03-harmonic_analyses/01-modal_superposition.py
+++ b/examples/03-harmonic_analyses/01-modal_superposition.py
@@ -21,8 +21,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create data sources
 # ~~~~~~~~~~~~~~~~~~~

--- a/examples/04-advanced/01-solve_harmonic_problem.py
+++ b/examples/04-advanced/01-solve_harmonic_problem.py
@@ -20,8 +20,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create 2D (x,y) matrix fields for inertia, damping, and stiffness.
 

--- a/examples/04-advanced/02-volume_averaged_stress.py
+++ b/examples/04-advanced/02-volume_averaged_stress.py
@@ -20,8 +20,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create a model targeting a given result file
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/04-advanced/03-exchange_data_between_servers.py
+++ b/examples/04-advanced/03-exchange_data_between_servers.py
@@ -21,8 +21,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create two servers
 # ~~~~~~~~~~~~~~~~~~

--- a/examples/04-advanced/04-extrapolation_stress_3d.py
+++ b/examples/04-advanced/04-extrapolation_stress_3d.py
@@ -40,8 +40,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Get the data source's analysis of integration points and analysis reference
 datafile = examples.download_extrapolation_3d_result()

--- a/examples/04-advanced/05-extrapolation_strain_2d.py
+++ b/examples/04-advanced/05-extrapolation_strain_2d.py
@@ -40,8 +40,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Get the data source's analyse of integration points and data source's analyse reference
 datafile = examples.download_extrapolation_2d_result()

--- a/examples/04-advanced/06-stress_gradient_path.py
+++ b/examples/04-advanced/06-stress_gradient_path.py
@@ -28,8 +28,6 @@ from ansys.dpf.core import operators as ops
 from ansys.dpf.core.plotter import DpfPlotter
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Open an example and print out the ``Model`` object. The
 # :class:`Model <ansys.dpf.core.model.Model>` class helps to organize access

--- a/examples/04-advanced/07-load_plugin.py
+++ b/examples/04-advanced/07-load_plugin.py
@@ -17,8 +17,6 @@ This example shows how to load a plugin that is not loaded automatically.
 from ansys.dpf import core as dpf
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 server = dpf.global_server()
 
 ###############################################################################

--- a/examples/05-file-IO/00-hdf5_double_float_comparison.py
+++ b/examples/05-file-IO/00-hdf5_double_float_comparison.py
@@ -26,8 +26,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 tmpdir = tempfile.mkdtemp()
 
 ###############################################################################

--- a/examples/05-file-IO/01-reduced_matrices_export.py
+++ b/examples/05-file-IO/01-reduced_matrices_export.py
@@ -25,8 +25,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 tmpdir = tempfile.mkdtemp()
 
 ###############################################################################

--- a/examples/05-file-IO/04-basic-load-file.py
+++ b/examples/05-file-IO/04-basic-load-file.py
@@ -23,8 +23,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 model = dpf.Model(examples.find_simple_bar())
 mesh = model.metadata.meshed_region
 

--- a/examples/06-plotting/04-plot_on_path.py
+++ b/examples/06-plotting/04-plot_on_path.py
@@ -22,8 +22,6 @@ from ansys.dpf.core import operators as ops
 from ansys.dpf.core.plotter import DpfPlotter
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Plot path
 # ~~~~~~~~~

--- a/examples/06-plotting/05-plot_on_warped_mesh.py
+++ b/examples/06-plotting/05-plot_on_warped_mesh.py
@@ -17,8 +17,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 # Get and show the initial model
 model = dpf.Model(examples.find_multishells_rst())
 print(model)

--- a/examples/06-plotting/07-plot_on_geometries.py
+++ b/examples/06-plotting/07-plot_on_geometries.py
@@ -28,7 +28,6 @@ from ansys.dpf.core.geometry import Line, Plane, Points
 from ansys.dpf.core.plotter import DpfPlotter
 from ansys.dpf.core.fields_factory import field_from_array
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
 
 ###############################################################################
 # Load model from examples and print information:

--- a/examples/07-distributed-post/02-distributed-msup_expansion.py
+++ b/examples/07-distributed-post/02-distributed-msup_expansion.py
@@ -80,8 +80,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Configure the servers
 # ~~~~~~~~~~~~~~~~~~~~~

--- a/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
+++ b/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
@@ -84,8 +84,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Configure the servers
 # ~~~~~~~~~~~~~~~~~~~~~

--- a/examples/07-distributed-post/06-distributed_stress_averaging.py
+++ b/examples/07-distributed-post/06-distributed_stress_averaging.py
@@ -22,8 +22,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Configure the servers
 # ~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/08-python-operators/00-wrapping_numpy_capabilities.py
+++ b/examples/08-python-operators/00-wrapping_numpy_capabilities.py
@@ -42,8 +42,6 @@ from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 GITHUB_SOURCE_URL = (
     "https://github.com/pyansys/pydpf-core/" "raw/examples/first_python_plugins/python_plugins"
 )

--- a/examples/08-python-operators/01-package_python_operators.py
+++ b/examples/08-python-operators/01-package_python_operators.py
@@ -43,8 +43,6 @@ from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 print("\033[1m average_filter_plugin")
 file_list = ["__init__.py", "operators.py", "operators_loader.py", "common.py"]
 plugin_folder = None

--- a/examples/08-python-operators/02-python_operators_with_dependencies.py
+++ b/examples/08-python-operators/02-python_operators_with_dependencies.py
@@ -45,8 +45,6 @@ from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 print("\033[1m gltf_plugin")
 file_list = [
     "gltf_plugin/__init__.py",

--- a/examples/09-averaging/01-average_across_bodies.py
+++ b/examples/09-averaging/01-average_across_bodies.py
@@ -32,8 +32,6 @@ from ansys.dpf.core import operators as ops
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Load the simulation results from an RST file and create a model of it.
 

--- a/examples/10-mesh_operations/05-skin_extraction.py
+++ b/examples/10-mesh_operations/05-skin_extraction.py
@@ -18,8 +18,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create a model object to establish a connection with an
 # example result file and then extract:

--- a/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
+++ b/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
@@ -26,8 +26,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create a model object to establish a connection with an example result file:
 model = dpf.Model(examples.download_hemisphere())

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,3 +1,3 @@
-ansys-dpf-gate==0.3.1.dev0
-ansys-dpf-gatebin==0.3.1.dev0
-ansys-grpc-dpf==0.7.1.dev0
+ansys-dpf-gate==0.3.2.dev0
+ansys-dpf-gatebin==0.3.2.dev0
+ansys-grpc-dpf==0.7.2.dev0

--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -81,7 +81,11 @@ from ansys.dpf.core import check_version
 from ansys.dpf.core import path_utilities
 from ansys.dpf.core import settings
 from ansys.dpf.core.server_factory import ServerConfig, AvailableServerConfigs
-from ansys.dpf.core.server_context import set_default_server_context, AvailableServerContexts
+from ansys.dpf.core.server_context import (
+    set_default_server_context,
+    AvailableServerContexts,
+    LicenseContextManager
+)
 from ansys.dpf.core.unit_system import UnitSystem, unit_systems
 
 # for matplotlib

--- a/src/ansys/dpf/core/runtime_config.py
+++ b/src/ansys/dpf/core/runtime_config.py
@@ -182,3 +182,18 @@ class RuntimeCoreConfig(_RuntimeConfig):
     @num_threads.setter
     def num_threads(self, value):
         self._data_tree.add(num_threads=int(value))
+
+    @property
+    def license_timeout_in_seconds(self):
+        """Sets the default number of threads to use for all operators,
+        default is omp_get_num_threads.
+
+        Returns
+        -------
+        float
+        """
+        return self._data_tree.get_as("license_timeout_in_seconds", types.double)
+
+    @license_timeout_in_seconds.setter
+    def license_timeout_in_seconds(self, value):
+        self._data_tree.add(license_timeout_in_seconds=float(value))

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -108,7 +108,7 @@ class LicenseContextManager:
 
         self._server = server_module.get_or_create_server(server)
         if not self._server.meet_version("6.1"):
-            raise errors.DpfVersionNotSupported("5.0")
+            raise errors.DpfVersionNotSupported("6.1")
         self._license_checkout_operator = dpf_operator.Operator(
             "license_checkout", server=self._server
         )

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -217,7 +217,7 @@ class AvailableServerContexts:
 
 DPF_SERVER_CONTEXT_ENV = "ANSYS_DPF_SERVER_CONTEXT"
 
-SERVER_CONTEXT = AvailableServerContexts.entry
+SERVER_CONTEXT = AvailableServerContexts.premium
 if DPF_SERVER_CONTEXT_ENV in os.environ.keys():
     default_context = os.getenv(DPF_SERVER_CONTEXT_ENV)
     try:

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -92,8 +92,7 @@ class LicenseContextManager:
     >>> op.inputs.field(field)
     >>> op.inputs.threshold(0.0)
     >>> with dpf.LicenseContextManager(
-    ...    increment_name="preppost", license_timeout_in_seconds=1.)
-    ...    as lic:
+    ...    increment_name="preppost", license_timeout_in_seconds=1.) as lic:
     ...    out = op.outputs.field()
 
     Notes

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -236,7 +236,7 @@ if DPF_SERVER_CONTEXT_ENV in os.environ.keys():
 
 def set_default_server_context(context=AvailableServerContexts.premium) -> None:
     """This context will be applied by default to any new server as well as
-    the global server, if it's running.
+    the global server, if it's running as Entry and requested context is Premium.
 
     The context allows to choose which capabilities are available server side.
 
@@ -254,5 +254,5 @@ def set_default_server_context(context=AvailableServerContexts.premium) -> None:
 
     global SERVER_CONTEXT
     SERVER_CONTEXT = context
-    if SERVER is not None:
+    if SERVER is not None and context == AvailableServerContexts.premium:
         SERVER.apply_context(context)

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -12,6 +12,8 @@ ANSYS_DPF_SERVER_CONTEXT=ENTRY and ANSYS_DPF_SERVER_CONTEXT=PREMIUM can be used.
 import os
 import warnings
 from enum import Enum
+from ansys.dpf.core import dpf_operator
+from ansys.dpf.core import errors
 
 
 class LicensingContextType(Enum):
@@ -36,6 +38,111 @@ class LicensingContextType(Enum):
         ):
             return False
         return True
+
+
+class LicenseContextManager:
+    """Can be optionally used to pre checkout a licence before using licensed DPF Operators.
+    Improves performances if many Operators requiring licensing are used afterwards.
+    It can also be used to force checkout before running a script when few
+    ANSYS license increments are available.
+    Check in the license when the object is deleted.
+
+    Parameters
+    ----------
+    increment_name: str, optional
+         License increment to check out. To improve a script efficiency, this license increment
+         should be consistent with the increments required by the following Operators. If ``None``,
+         the first available increment of this
+         `list <https://dpf.docs.pyansys.com/version/dev/user_guide/getting_started_with_dpf_server.
+         html#ansys-licensing>`_
+         is checked out.
+    license_timeout_in_seconds: float, optional
+         If no increment is available until then, check out fails. Defaults is:
+         :py:func:`ansys.dpf.core.runtime_config.RuntimeCoreConfig.license_timeout_in_seconds`
+    server : server.DPFServer, optional
+        Server with the channel connected to the remote or local instance. The
+        default is ``None``, in which case an attempt is made to use the global
+        server.
+
+    Examples
+    --------
+    Using a context manager
+    >>> from ansys.dpf import core as dpf
+    >>> dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
+    >>> field = dpf.Field()
+    >>> field.append([0., 0., 0.], 1)
+    >>> op = dpf.operators.filter.field_high_pass()
+    >>> op.inputs.field(field)
+    >>> op.inputs.threshold(0.0)
+    >>> with dpf.LicenseContextManager() as lic:
+    ...    out = op.outputs.field()
+
+    Using an instance
+    >>> lic = dpf.LicenseContextManager()
+    >>> op.inputs.field(field)
+    >>> op.inputs.threshold(0.0)
+    >>> out = op.outputs.field()
+    >>> lic = None
+
+    Using a context manager and choosing license options
+    >>> op.inputs.field(field)
+    >>> op.inputs.threshold(0.0)
+    >>> out = op.outputs.field()
+    >>> op = dpf.operators.filter.field_high_pass()
+    >>> op.inputs.field(field)
+    >>> op.inputs.threshold(0.0)
+    >>> with dpf.LicenseContextManager(
+    ...    increment_name="preppost", license_timeout_in_seconds=1.)
+    ...    as lic:
+    ...    out = op.outputs.field()
+
+    Notes
+    -----
+    Available from 6.1 server version.
+    """
+
+    def __init__(
+        self, increment_name: str = None, license_timeout_in_seconds: float = None, server=None
+    ):
+        from ansys.dpf.core import server as server_module
+
+        self._server = server_module.get_or_create_server(server)
+        if not self._server.meet_version("6.1"):
+            raise errors.DpfVersionNotSupported("5.0")
+        self._license_checkout_operator = dpf_operator.Operator(
+            "license_checkout", server=self._server
+        )
+        if increment_name is not None:
+            self._license_checkout_operator.connect(0, increment_name)
+        if license_timeout_in_seconds is not None:
+            self._license_checkout_operator.connect(1, license_timeout_in_seconds)
+        self._license_checkout_operator.run()
+
+    def release_data(self):
+        """Release the data."""
+        self._license_checkout_operator = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        if tb is None:
+            self.release_data()
+
+    def __del__(self):
+        self.release_data()
+        pass
+
+    @property
+    def status(self):
+        """Returns a string with the list of checked out increments
+
+        Returns
+        -------
+        str
+        """
+        status_operator = dpf_operator.Operator("license_status", server=self._server)
+        return status_operator.eval()
 
 
 class ServerContext:

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -234,7 +234,7 @@ if DPF_SERVER_CONTEXT_ENV in os.environ.keys():
         )
 
 
-def set_default_server_context(context=AvailableServerContexts.entry) -> None:
+def set_default_server_context(context=AvailableServerContexts.premium) -> None:
     """This context will be applied by default to any new server as well as
     the global server, if it's running.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,12 +504,3 @@ def set_context_back_to_premium(request):
             pass
 
     request.addfinalizer(revert)
-
-
-# to call at the end
-if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0:
-    core.server.shutdown_all_session_servers()
-    try:
-        core.set_default_server_context(core.AvailableServerContexts.premium)
-    except core.errors.DpfVersionNotSupported:
-        pass

--- a/tests/test_data_tree.py
+++ b/tests/test_data_tree.py
@@ -298,6 +298,12 @@ def test_runtime_core_config(server_type):
     assert num_threads == 4
     core_config.num_threads = num_threads_init
     assert core_config.num_threads == num_threads_init
+    timeout_init = core_config.license_timeout_in_seconds
+    core_config.license_timeout_in_seconds = 4.0
+    license_timeout_in_seconds = core_config.license_timeout_in_seconds
+    assert license_timeout_in_seconds == 4.0
+    core_config.license_timeout_in_seconds = timeout_init
+    assert core_config.license_timeout_in_seconds == timeout_init
 
 
 @conftest.raises_for_servers_version_under("4.0")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -489,7 +489,7 @@ def test_context_environment_variable(reset_context_environment_variable):
 @pytest.mark.order(1)
 @pytest.mark.skipif(
     running_docker
-    or os.environ.get("ANSYS_DPF_ACCEPT_LA", None) is None
+    or os.environ.get("ANSYS_DPF_ACCEPT_LA", "") is ""
     or not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
     reason="Tests ANSYS_DPF_ACCEPT_LA",
 )
@@ -509,7 +509,7 @@ def test_license_agr(set_context_back_to_premium):
 
 @pytest.mark.order(2)
 @pytest.mark.skipif(
-    os.environ.get("ANSYS_DPF_ACCEPT_LA", None) is None
+    os.environ.get("ANSYS_DPF_ACCEPT_LA", "") is ""
     or not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
     reason="Tests ANSYS_DPF_ACCEPT_LA",
 )


### PR DESCRIPTION
Starting with `dpf_server_2023.2.pre1`, the licensing logic changes to an operator-based logic where each operator is tagged as either requiring a given (specific or any among a list) license to be checked-out, or as only requiring a license to exist.
This means the `ServerContext` being **Premium** means operators are **allowed** to check-out a license, and is the default behavior.
The `ServerContext` being **Entry** means operators are **not allowed** to check-out a license and will throw an error.

A DPF Server started with a **Premium** `ServerContext` cannot be set back to **Entry**.
Thus, the `server_context.py/set_default_server_context()` function should not try to apply an new default **Entry** context to an already running global server started as **Premium**.

For testing, having new servers being **Premium** by default means that:
- no more need to set the default context as **Premium** in the `conftest.py`.
- features to be tested as **Entry** should use a specific server started as **Entry**.

For examples:
- still need to mark the examples as requiring **Premium**
- no more need to set_default_server_context(Premium) in the first lines.
