### PR TITLE
Set Premium as the default ServerContext

### DIFF
--- a/examples/03-harmonic_analyses/00-multi_harmonic.py
+++ b/examples/03-harmonic_analyses/00-multi_harmonic.py
@@ -20,8 +20,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Begin by downloading the example harmonic result. This result is
 # not included in the core module by default to speed up the install.

--- a/examples/03-harmonic_analyses/00-multi_harmonic.py
+++ b/examples/03-harmonic_analyses/00-multi_harmonic.py
@@ -7,11 +7,6 @@ Multi-harmonic response example
 This example shows how to compute a multi-harmonic response
 using ``fft`` transformations.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
-
 """
 import matplotlib.pyplot as pyplot
 

--- a/examples/03-harmonic_analyses/01-modal_superposition.py
+++ b/examples/03-harmonic_analyses/01-modal_superposition.py
@@ -11,10 +11,6 @@ a structure under given boundary conditions in a range of frequencies.
 Doing this expansion "on demand" in DPF instead of in the solver
 reduces the size of the result files.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 from ansys.dpf import core as dpf

--- a/examples/03-harmonic_analyses/01-modal_superposition.py
+++ b/examples/03-harmonic_analyses/01-modal_superposition.py
@@ -21,8 +21,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create data sources
 # ~~~~~~~~~~~~~~~~~~~

--- a/examples/04-advanced/01-solve_harmonic_problem.py
+++ b/examples/04-advanced/01-solve_harmonic_problem.py
@@ -8,10 +8,6 @@ This example shows how to create a harmonic (over frequencies) fields
 container for an analysis with damping. This fields container is then used to
 solve the problem Ma+Dv+Ku=F by inverting the matrix
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 import math

--- a/examples/04-advanced/01-solve_harmonic_problem.py
+++ b/examples/04-advanced/01-solve_harmonic_problem.py
@@ -20,8 +20,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create 2D (x,y) matrix fields for inertia, damping, and stiffness.
 

--- a/examples/04-advanced/02-volume_averaged_stress.py
+++ b/examples/04-advanced/02-volume_averaged_stress.py
@@ -10,10 +10,6 @@ For each list of elements, the elemental stress equivalent is multiplied by the
 volume of each element. This result is then accumulated to divide it by the
 total volume.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples

--- a/examples/04-advanced/02-volume_averaged_stress.py
+++ b/examples/04-advanced/02-volume_averaged_stress.py
@@ -20,8 +20,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create a model targeting a given result file
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/04-advanced/03-exchange_data_between_servers.py
+++ b/examples/04-advanced/03-exchange_data_between_servers.py
@@ -10,10 +10,6 @@ with a part on both servers. This example shows how you can read data
 from a given machine and transform this data on another machine
 without any more difficulties than working on a local computer.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 from ansys.dpf import core as dpf

--- a/examples/04-advanced/03-exchange_data_between_servers.py
+++ b/examples/04-advanced/03-exchange_data_between_servers.py
@@ -21,8 +21,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create two servers
 # ~~~~~~~~~~~~~~~~~~

--- a/examples/04-advanced/04-extrapolation_stress_3d.py
+++ b/examples/04-advanced/04-extrapolation_stress_3d.py
@@ -40,8 +40,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Get the data source's analysis of integration points and analysis reference
 datafile = examples.download_extrapolation_3d_result()

--- a/examples/04-advanced/04-extrapolation_stress_3d.py
+++ b/examples/04-advanced/04-extrapolation_stress_3d.py
@@ -30,10 +30,6 @@ Here are the steps for extrapolation:
 #. Compare the result for nodal stress from the data source
    and the nodal stress computed by the extrapolation method.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 from ansys.dpf import core as dpf

--- a/examples/04-advanced/05-extrapolation_strain_2d.py
+++ b/examples/04-advanced/05-extrapolation_strain_2d.py
@@ -40,8 +40,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Get the data source's analyse of integration points and data source's analyse reference
 datafile = examples.download_extrapolation_2d_result()

--- a/examples/04-advanced/05-extrapolation_strain_2d.py
+++ b/examples/04-advanced/05-extrapolation_strain_2d.py
@@ -30,10 +30,6 @@ Here are the steps for extrapolation:
 #. Compare the result for nodal elastic strain from the data source
    and the nodal elastic strain computed by the extrapolation method.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 from ansys.dpf import core as dpf

--- a/examples/04-advanced/06-stress_gradient_path.py
+++ b/examples/04-advanced/06-stress_gradient_path.py
@@ -28,8 +28,6 @@ from ansys.dpf.core import operators as ops
 from ansys.dpf.core.plotter import DpfPlotter
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Open an example and print out the ``Model`` object. The
 # :class:`Model <ansys.dpf.core.model.Model>` class helps to organize access

--- a/examples/04-advanced/06-stress_gradient_path.py
+++ b/examples/04-advanced/06-stress_gradient_path.py
@@ -10,10 +10,6 @@ Because the example is based on creating a path along the normal, the selected n
 must be on the surface of the geometry.
 A path is created of a defined length.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/04-advanced/07-load_plugin.py
+++ b/examples/04-advanced/07-load_plugin.py
@@ -6,10 +6,6 @@ Load plugin
 
 This example shows how to load a plugin that is not loaded automatically.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/04-advanced/07-load_plugin.py
+++ b/examples/04-advanced/07-load_plugin.py
@@ -17,8 +17,6 @@ This example shows how to load a plugin that is not loaded automatically.
 from ansys.dpf import core as dpf
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 server = dpf.global_server()
 
 ###############################################################################

--- a/examples/05-file-IO/00-hdf5_double_float_comparison.py
+++ b/examples/05-file-IO/00-hdf5_double_float_comparison.py
@@ -26,8 +26,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 tmpdir = tempfile.mkdtemp()
 
 ###############################################################################

--- a/examples/05-file-IO/00-hdf5_double_float_comparison.py
+++ b/examples/05-file-IO/00-hdf5_double_float_comparison.py
@@ -8,10 +8,6 @@ HDF5 export and compare precision
 This example shows how to use HDF5 format to export and
 compare simple precision versus double precision.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/05-file-IO/01-reduced_matrices_export.py
+++ b/examples/05-file-IO/01-reduced_matrices_export.py
@@ -25,8 +25,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 tmpdir = tempfile.mkdtemp()
 
 ###############################################################################

--- a/examples/05-file-IO/01-reduced_matrices_export.py
+++ b/examples/05-file-IO/01-reduced_matrices_export.py
@@ -7,10 +7,6 @@ Get reduced matrices and make export
 This example shows how to get reduced matrices and
 export them to HDF5 and CSV files.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/05-file-IO/04-basic-load-file.py
+++ b/examples/05-file-IO/04-basic-load-file.py
@@ -23,8 +23,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 model = dpf.Model(examples.find_simple_bar())
 mesh = model.metadata.meshed_region
 

--- a/examples/05-file-IO/04-basic-load-file.py
+++ b/examples/05-file-IO/04-basic-load-file.py
@@ -9,10 +9,6 @@ This example shows how to write and upload files on the server machine and then
 download them back on the client side. The resulting fields container is then
 exported to a CSV file.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/06-plotting/04-plot_on_path.py
+++ b/examples/06-plotting/04-plot_on_path.py
@@ -22,8 +22,6 @@ from ansys.dpf.core import operators as ops
 from ansys.dpf.core.plotter import DpfPlotter
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Plot path
 # ~~~~~~~~~

--- a/examples/06-plotting/04-plot_on_path.py
+++ b/examples/06-plotting/04-plot_on_path.py
@@ -8,10 +8,6 @@ Plot results on a specific path
 This example shows how to get a result mapped over a specific path
 and how to plot it.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 import matplotlib.pyplot as plt

--- a/examples/06-plotting/05-plot_on_warped_mesh.py
+++ b/examples/06-plotting/05-plot_on_warped_mesh.py
@@ -17,8 +17,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 # Get and show the initial model
 model = dpf.Model(examples.find_multishells_rst())
 print(model)

--- a/examples/06-plotting/05-plot_on_warped_mesh.py
+++ b/examples/06-plotting/05-plot_on_warped_mesh.py
@@ -7,10 +7,6 @@ Warp the mesh by a field for plotting
 This example shows how to warp the mesh by a vector field,
 enabling to plot on the deformed geometry.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 from ansys.dpf import core as dpf

--- a/examples/06-plotting/07-plot_on_geometries.py
+++ b/examples/06-plotting/07-plot_on_geometries.py
@@ -28,7 +28,6 @@ from ansys.dpf.core.geometry import Line, Plane, Points
 from ansys.dpf.core.plotter import DpfPlotter
 from ansys.dpf.core.fields_factory import field_from_array
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
 
 ###############################################################################
 # Load model from examples and print information:

--- a/examples/06-plotting/07-plot_on_geometries.py
+++ b/examples/06-plotting/07-plot_on_geometries.py
@@ -6,10 +6,6 @@ Plot on geometry elements
 This example shows how to plot a certain field in different geometric
 objects such as points, lines and planes.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 

--- a/examples/07-distributed-post/02-distributed-msup_expansion.py
+++ b/examples/07-distributed-post/02-distributed-msup_expansion.py
@@ -66,10 +66,6 @@ chain that is used to compute the final result.
         "expansion" -> "component";
     }
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/07-distributed-post/02-distributed-msup_expansion.py
+++ b/examples/07-distributed-post/02-distributed-msup_expansion.py
@@ -80,8 +80,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Configure the servers
 # ~~~~~~~~~~~~~~~~~~~~~

--- a/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
+++ b/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
@@ -69,10 +69,6 @@ chain that is used to compute the final result.
         "expansion" -> "component";
     }
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
+++ b/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
@@ -84,8 +84,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Configure the servers
 # ~~~~~~~~~~~~~~~~~~~~~

--- a/examples/07-distributed-post/06-distributed_stress_averaging.py
+++ b/examples/07-distributed-post/06-distributed_stress_averaging.py
@@ -22,8 +22,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Configure the servers
 # ~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/07-distributed-post/06-distributed_stress_averaging.py
+++ b/examples/07-distributed-post/06-distributed_stress_averaging.py
@@ -8,10 +8,6 @@ This example shows how stress can be read from distributed files and
 averaged from elemental nodal to nodal in parallel with a distributed workflow.
 After remote post-processing, results are merged on the local process.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/08-python-operators/00-wrapping_numpy_capabilities.py
+++ b/examples/08-python-operators/00-wrapping_numpy_capabilities.py
@@ -16,10 +16,6 @@ be wrapped in Python plugins.
     This example requires DPF 4.0 (Ansys 2022R2) or above.
     For more information, see :ref:`ref_compatibility`.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/08-python-operators/00-wrapping_numpy_capabilities.py
+++ b/examples/08-python-operators/00-wrapping_numpy_capabilities.py
@@ -42,8 +42,6 @@ from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 GITHUB_SOURCE_URL = (
     "https://github.com/pyansys/pydpf-core/" "raw/examples/first_python_plugins/python_plugins"
 )

--- a/examples/08-python-operators/01-package_python_operators.py
+++ b/examples/08-python-operators/01-package_python_operators.py
@@ -43,8 +43,6 @@ from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 print("\033[1m average_filter_plugin")
 file_list = ["__init__.py", "operators.py", "operators_loader.py", "common.py"]
 plugin_folder = None

--- a/examples/08-python-operators/01-package_python_operators.py
+++ b/examples/08-python-operators/01-package_python_operators.py
@@ -20,10 +20,6 @@ For this example, the plug-in package contains two different operators:
     This example requires DPF 4.0 (Ansys 2022R2) or above.
     For more information, see :ref:`ref_compatibility`.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/08-python-operators/02-python_operators_with_dependencies.py
+++ b/examples/08-python-operators/02-python_operators_with_dependencies.py
@@ -22,10 +22,6 @@ file at the given path.
     This example requires DPF 4.0 (Ansys 2022R2) or above.
     For more information, see :ref:`ref_compatibility`.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 
 ###############################################################################

--- a/examples/08-python-operators/02-python_operators_with_dependencies.py
+++ b/examples/08-python-operators/02-python_operators_with_dependencies.py
@@ -45,8 +45,6 @@ from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 print("\033[1m gltf_plugin")
 file_list = [
     "gltf_plugin/__init__.py",

--- a/examples/09-averaging/01-average_across_bodies.py
+++ b/examples/09-averaging/01-average_across_bodies.py
@@ -19,10 +19,6 @@ of a postprocessing workflow can be different when averaging and when not.
     This example requires DPF 6.1 or above.
     For more information, see :ref:`ref_compatibility`.
 
-.. note::
-    This example requires the Premium Server Context.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 ###############################################################################
 # Import the necessary modules

--- a/examples/09-averaging/01-average_across_bodies.py
+++ b/examples/09-averaging/01-average_across_bodies.py
@@ -32,8 +32,6 @@ from ansys.dpf.core import operators as ops
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Load the simulation results from an RST file and create a model of it.
 

--- a/examples/10-mesh_operations/05-skin_extraction.py
+++ b/examples/10-mesh_operations/05-skin_extraction.py
@@ -18,8 +18,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core import operators as ops
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create a model object to establish a connection with an
 # example result file and then extract:

--- a/examples/10-mesh_operations/05-skin_extraction.py
+++ b/examples/10-mesh_operations/05-skin_extraction.py
@@ -7,10 +7,6 @@ Extract the skin from a mesh
 Extracting the skin of a mesh to reduce the amount of data to operate on
 can be useful for specific results and for performance.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
 """
 # Import necessary modules
 from ansys.dpf import core as dpf

--- a/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
+++ b/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
@@ -15,11 +15,6 @@ the GCS, a transformation is required after the rotation to get the correct coor
 
 The script below demonstrates the methodology using PyDPF.
 
-.. note::
-    This example requires the Premium ServerContext.
-    For more information, see :ref:`user_guide_server_context`.
-
-
 """
 # Import necessary modules
 from ansys.dpf import core as dpf

--- a/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
+++ b/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
@@ -26,8 +26,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
 
-dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
-
 ###############################################################################
 # Create a model object to establish a connection with an example result file:
 model = dpf.Model(examples.download_hemisphere())

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -217,7 +217,7 @@ class AvailableServerContexts:
 
 DPF_SERVER_CONTEXT_ENV = "ANSYS_DPF_SERVER_CONTEXT"
 
-SERVER_CONTEXT = AvailableServerContexts.entry
+SERVER_CONTEXT = AvailableServerContexts.premium
 if DPF_SERVER_CONTEXT_ENV in os.environ.keys():
     default_context = os.getenv(DPF_SERVER_CONTEXT_ENV)
     try:

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -236,7 +236,7 @@ if DPF_SERVER_CONTEXT_ENV in os.environ.keys():
 
 def set_default_server_context(context=AvailableServerContexts.premium) -> None:
     """This context will be applied by default to any new server as well as
-    the global server, if it's running.
+    the global server, if it's running as Entry and requested context is Premium.
 
     The context allows to choose which capabilities are available server side.
 
@@ -254,5 +254,5 @@ def set_default_server_context(context=AvailableServerContexts.premium) -> None:
 
     global SERVER_CONTEXT
     SERVER_CONTEXT = context
-    if SERVER is not None:
+    if SERVER is not None and context == AvailableServerContexts.premium:
         SERVER.apply_context(context)

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -234,7 +234,7 @@ if DPF_SERVER_CONTEXT_ENV in os.environ.keys():
         )
 
 
-def set_default_server_context(context=AvailableServerContexts.entry) -> None:
+def set_default_server_context(context=AvailableServerContexts.premium) -> None:
     """This context will be applied by default to any new server as well as
     the global server, if it's running.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,12 +504,3 @@ def set_context_back_to_premium(request):
             pass
 
     request.addfinalizer(revert)
-
-
-# to call at the end
-if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0:
-    core.server.shutdown_all_session_servers()
-    try:
-        core.set_default_server_context(core.AvailableServerContexts.premium)
-    except core.errors.DpfVersionNotSupported:
-        pass


### PR DESCRIPTION
Starting with `dpf_server_2023.2.pre1`, the licensing logic changes to an operator-based logic where each operator is tagged as either requiring a given (specific or any among a list) license to be checked-out, or as only requiring a license to exist.
This means the `ServerContext` being **Premium** means operators are **allowed** to check-out a license, and is the default behavior.
The `ServerContext` being **Entry** means operators are **not allowed** to check-out a license and will throw an error.

A DPF Server started with a **Premium** `ServerContext` cannot be set back to **Entry**.
Thus, the `server_context.py/set_default_server_context()` function should not try to apply an new default **Entry** context to an already running global server started as **Premium**.

For testing, having new servers being **Premium** by default means that:
- no more need to set the default context as **Premium** in the `conftest.py`.
- features to be tested as **Entry** should use a specific server started as **Entry**.

For examples:
- still need to mark the examples as requiring **Premium**
- no more need to set_default_server_context(Premium) in the first lines.
