### PR TITLE
Update self.live variable when shutting down

### DIFF
--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -778,7 +778,7 @@ class GrpcServer(CServer):
                     self._shutdown_func[0](self._shutdown_func[1])
             except Exception as e:
                 warnings.warn("couldn't shutdown server: " + str(e.args))
-            
+
             self._docker_config.remove_docker_image()
             self.live = False
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -267,17 +267,22 @@ def test_go_away_server():
         field = dpf.core.Field(server=s)
         assert field._internal_obj is not None
 
+
 @pytest.mark.skipif(
     not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0,
     reason="Not existing in version lower than 4.0",
 )
 def test_start_after_shutting_down_server():
-    remote_server = start_local_server(config=dpf.core.AvailableServerConfigs.GrpcServer, as_global=False)
+    remote_server = start_local_server(
+        config=dpf.core.AvailableServerConfigs.GrpcServer, as_global=False
+    )
     shutdown_all_session_servers()
 
     time.sleep(2.0)
 
-    remote_server = start_local_server(config=dpf.core.AvailableServerConfigs.GrpcServer, as_global=False)
+    remote_server = start_local_server(
+        config=dpf.core.AvailableServerConfigs.GrpcServer, as_global=False
+    )
     info = remote_server.info
     shutdown_all_session_servers()
     assert info is not None


### PR DESCRIPTION
self.live was updated for LegacyGrpcServer but was not for GrpcServer.

This causes issues when shutting down and starting a new server immediately from the same variable.

Perhaps it may be better to add a mechanism upper in the class hierarchy in BaseServer so this variable gets updated for every child class ?