### PR TITLE
Fix calls to doc-deploy-dev/stable pyansys actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          doc-artifact-name: HTML-doc-ansys-dpf-core
+          decompress-artifact: true
+
 
   examples:
     if: startsWith(github.head_ref, 'master') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -183,9 +183,3 @@ jobs:
           name: HTML-doc-${{env.PACKAGE_NAME}}
           path: HTML-doc-${{env.PACKAGE_NAME}}.zip
         if: always()
-
-      - name: "Upload HTML Documentation"
-        uses: actions/upload-artifact@v3
-        with:
-          name: documentation-html
-          path: docs/build/html

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -39,13 +39,11 @@ jobs:
           file: HTML-doc-ansys-dpf-core.zip
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Unzip the HMTL documentation"
-        uses: montudor/action-zip@v1
-        with:
-          args: unzip -qq HTML-doc-ansys-dpf-core.zip -d documentation-html
 
       - name: "Deploy the stable documentation"
         uses: pyansys/actions/doc-deploy-stable@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          doc-artifact-name: HTML-doc-ansys-dpf-core
+          decompress-artifact: true


### PR DESCRIPTION
Use the new input arguments of pyansys/actions/doc-deploy-dev|stable@v4 to skip the renaming and unzipping step

The previous implementation relied on a unzip step with renaming, unsing montudor/zip GitHub action.
However there is a known issue with the rights of the files once unzipped.
Furthermore, thanks to the v4 pyansys actions, this step is not even required.