### PR TITLE
Fix/plot quadratic elements

### DIFF
--- a/examples/04-advanced/02-volume_averaged_stress.py
+++ b/examples/04-advanced/02-volume_averaged_stress.py
@@ -48,7 +48,7 @@ vol_field = vol_op.outputs.fields_container()[0]
 # Find the minimum list of elements by node to get the volume check
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# get the connectivy and inverse connecitivity fields
+# get the connectivity and inverse connectivity fields
 connectivity_field = mesh.elements.connectivities_field
 nodal_connectivity_field = mesh.nodes.nodal_connectivity_field
 
@@ -83,10 +83,7 @@ with connectivity_field.as_local_field() as connectivity, \
                 # Get all nodes of the current elements for next iteration
                 current_node_indexes.extend(connectivity.get_entity_data(index))
 
-        node_index_to_el_ids[i] = dpf.Scoping(
-            ids=[elements_ids[index] for index in elements_indexes],
-            location=dpf.locations().elemental,
-        )
+        node_index_to_el_ids[i] = [elements_ids[index] for index in elements_indexes]
         node_index_to_found_volume[i] = volume
 
 ###############################################################################
@@ -128,7 +125,7 @@ seqvsum.scoping.ids = nodes_ids_to_compute
 volsum.data = datavolsum
 volsum.scoping.ids = nodes_ids_to_compute
 
-# use component wise divide to averaged the stress by the volume
+# use component wise divide to average the stress by the volume
 divide = ops.math.component_wise_divide(seqvsum, volsum)
 divide.run()
 

--- a/examples/04-advanced/04-extrapolation_stress_3d.py
+++ b/examples/04-advanced/04-extrapolation_stress_3d.py
@@ -38,7 +38,7 @@ from ansys.dpf.core import examples
 
 ###############################################################################
 # Get the data source's analysis of integration points and analysis reference
-datafile = examples.download_extrapolation_3d_result()
+datafile = examples.download_extrapolation_3d_result(return_local_path=True)
 
 # Get integration points (Gaussian points)
 data_integration_points = datafile["file_integrated"]

--- a/examples/06-plotting/00-basic_plotting.py
+++ b/examples/06-plotting/00-basic_plotting.py
@@ -54,6 +54,19 @@ mesh.plot(
     title="Mesh fc None",
     text="Mesh plot",
 )
+
+# The plotter transforms quadratic elements into their linear equivalents by default
+# for improved performance. This can be changed using the "as_linear=False" argument.
+# Note: semi-parabolic elements are always changed to their linear equivalents.
+mesh.plot(
+    as_linear=False,
+    field_or_fields_container=None,
+    shell_layers=None,
+    show_axes=True,
+    title="Mesh fc None",
+    text="Mesh plot as_linear=False",
+)
+
 # Additional PyVista kwargs are supported, such as:
 mesh.plot(
     off_screen=True,

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -512,6 +512,7 @@ class MeshedRegion:
         shell_layers=None,
         deform_by=None,
         scale_factor=1.0,
+        as_linear=True,
         **kwargs,
     ):
         """
@@ -528,6 +529,9 @@ class MeshedRegion:
             Defaults to None.
         scale_factor : float, optional
             Scaling factor to apply when warping the mesh. Defaults to 1.0.
+        as_linear : bool, optional
+            Whether to show quadratic elements as their linear equivalents (for faster rendering).
+            Defaults to ``True``.
         **kwargs : optional
             Additional keyword arguments for the plotter. For additional keyword
             arguments, see ``help(pyvista.plot)``.
@@ -552,6 +556,7 @@ class MeshedRegion:
                 show_axes=kwargs.pop("show_axes", True),
                 deform_by=deform_by,
                 scale_factor=scale_factor,
+                as_linear=as_linear,
                 **kwargs,
             )
 
@@ -562,6 +567,7 @@ class MeshedRegion:
             deform_by=deform_by,
             scale_factor=scale_factor,
             show_axes=kwargs.pop("show_axes", True),
+            as_linear=as_linear,
             **kwargs,
         )
         return pl.show_figure(**kwargs)

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -108,6 +108,7 @@ class MeshedRegion:
         self._full_grid = None
         self._elements = None
         self._nodes = None
+        self.as_linear = None
 
     def _get_scoping(self, loc=locations.nodal):
         """

--- a/src/ansys/dpf/core/model.py
+++ b/src/ansys/dpf/core/model.py
@@ -206,7 +206,7 @@ class Model:
         txt += str(self.metadata.time_freq_support)
         return txt
 
-    def plot(self, color="w", show_edges=True, **kwargs):
+    def plot(self, color="w", show_edges=True, as_linear=True, **kwargs):
         """Plot the mesh of the model.
 
         Parameters
@@ -215,6 +215,9 @@ class Model:
             color of the mesh faces in PyVista format. The default is white with ``"w"``.
         show_edges : bool
             Whether to show the mesh edges. The default is ``True``.
+        as_linear : bool, optional
+            Whether to show quadratic elements as their linear equivalents (for faster rendering).
+            Defaults to ``True``.
         **kwargs : optional
             Additional keyword arguments for the plotter. For additional keyword
             arguments, see ``help(pyvista.plot)``.
@@ -235,7 +238,12 @@ class Model:
         kwargs["color"] = color
         kwargs["show_edges"] = show_edges
         pl = DpfPlotter(**kwargs)
-        pl.add_mesh(self.metadata.meshed_region, show_axes=kwargs.pop("show_axes", True), **kwargs)
+        pl.add_mesh(
+            self.metadata.meshed_region,
+            show_axes=kwargs.pop("show_axes", True),
+            as_linear=as_linear,
+            **kwargs
+        )
         return pl.show_figure(**kwargs)
 
     @property

--- a/src/ansys/dpf/core/plotter.py
+++ b/src/ansys/dpf/core/plotter.py
@@ -286,7 +286,7 @@ class _PyVistaPlotter:
             grid = meshed_region.grid
         else:
             grid = meshed_region._as_vtk(
-                meshed_region.deform_by(deform_by, scale_factor, as_linear)
+                meshed_region.deform_by(deform_by, scale_factor), as_linear
             )
         grid.set_active_scalars(None)
         self._plotter.add_mesh(grid, scalars=overall_data, **kwargs_in)

--- a/src/ansys/dpf/core/plotter.py
+++ b/src/ansys/dpf/core/plotter.py
@@ -746,6 +746,7 @@ class Plotter:
         meshed_region=None,
         deform_by=None,
         scale_factor=1.0,
+        as_linear=True,
         **kwargs,
     ):
         """Plot the contour result on its mesh support.
@@ -765,6 +766,9 @@ class Plotter:
             Defaults to None.
         scale_factor : float, optional
             Scaling factor to apply when warping the mesh. Defaults to 1.0.
+        as_linear : bool, optional
+            Whether to show quadratic elements as their linear equivalents (for faster rendering).
+            Defaults to ``True``.
         **kwargs : optional
             Additional keyword arguments for the plotter. For more information,
             see ``help(pyvista.plot)``.
@@ -880,10 +884,14 @@ class Plotter:
             bound_method=self._internal_plotter._plotter.add_mesh, **kwargs
         )
         if deform_by:
-            grid = mesh._as_vtk(mesh.deform_by(deform_by, scale_factor))
+            grid = mesh._as_vtk(mesh.deform_by(deform_by, scale_factor), as_linear=as_linear)
             self._internal_plotter.add_scale_factor_legend(scale_factor, **kwargs)
         else:
-            grid = mesh.grid
+            if as_linear != mesh.as_linear:
+                grid = mesh._as_vtk(mesh.nodes.coordinates_field, as_linear=as_linear)
+                mesh.as_linear = as_linear
+            else:
+                grid = mesh.grid
         grid.clear_data()
         self._internal_plotter._plotter.add_mesh(grid, scalars=overall_data, **kwargs_in)
 

--- a/src/ansys/dpf/core/vtk_helper.py
+++ b/src/ansys/dpf/core/vtk_helper.py
@@ -246,6 +246,7 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
         """Return the starting point of a cell in the cells array"""
         return insert_ind + np.arange(insert_ind.size)
 
+    cells_insert_ind = compute_offset()
     # convert kAns to VTK cell type
     offset = None
     if as_linear:
@@ -253,29 +254,28 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
         vtk_cell_type = VTK_LINEAR_MAPPING[etypes]
 
         # Create a global mask of connectivity values to take
-        mask = np.full(cells.shape, False)
-        mask[compute_offset()] = True
+        mask = np.full(cells.shape, True)
 
         # Get a mask of quad8 elements in etypes
         quad8_mask = etypes == 6
         # If any quad8
         if np.any(quad8_mask):  # kAnsQuad8
             # Get the starting indices of quad8 elements in cells
-            insert_ind_quad8 = insert_ind[quad8_mask]
-            insert_ind_quad8 += np.arange(insert_ind_quad8.size)
-            mask[insert_ind_quad8 + 1] = True
-            mask[insert_ind_quad8 + 2] = True
-            mask[insert_ind_quad8 + 3] = True
-            mask[insert_ind_quad8 + 4] = True
+            insert_ind_quad8 = cells_insert_ind[quad8_mask]
+            # insert_ind_quad8 += np.arange(insert_ind_quad8.size)
+            mask[insert_ind_quad8 + 5] = False
+            mask[insert_ind_quad8 + 6] = False
+            mask[insert_ind_quad8 + 7] = False
+            mask[insert_ind_quad8 + 8] = False
             cells[insert_ind_quad8] //= 2
 
         tri6_mask = etypes == 4  # kAnsTri6 = 4
         if np.any(tri6_mask):
-            insert_ind_tri6 = insert_ind[tri6_mask]
-            insert_ind_tri6 += np.arange(insert_ind_tri6.size)
-            mask[insert_ind_tri6 + 1] = True
-            mask[insert_ind_tri6 + 2] = True
-            mask[insert_ind_tri6 + 3] = True
+            insert_ind_tri6 = cells_insert_ind[tri6_mask]
+            # insert_ind_tri6 += np.arange(insert_ind_tri6.size)
+            mask[insert_ind_tri6 + 4] = False
+            mask[insert_ind_tri6 + 5] = False
+            mask[insert_ind_tri6 + 6] = False
             cells[insert_ind_tri6] //= 2
         cells = cells[mask]
 

--- a/src/ansys/dpf/core/vtk_helper.py
+++ b/src/ansys/dpf/core/vtk_helper.py
@@ -301,14 +301,19 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
                 mask[semi_indices_in_cells[semi_quad8] + 8] = False
                 cells[semi_indices_in_cells[semi_quad8]] //= 2
 
-                vtk_cell_type[cells[cells_insert_ind[etypes == 6]] == 4] = VTK_LINEAR_MAPPING[6]
+                quad8_mask = etypes == 6
+                semi_quad8_mask = (cells[cells_insert_ind] == 4) & quad8_mask
+                vtk_cell_type[semi_quad8_mask] = VTK_LINEAR_MAPPING[6]
             semi_tri6 = semi_sizes == 6
             if semi_tri6.any():
                 mask[semi_indices_in_cells[semi_tri6] + 4] = False
                 mask[semi_indices_in_cells[semi_tri6] + 5] = False
                 mask[semi_indices_in_cells[semi_tri6] + 6] = False
                 cells[semi_indices_in_cells[semi_tri6]] //= 2
-                vtk_cell_type[cells[cells_insert_ind[etypes == 4]] == 3] = VTK_LINEAR_MAPPING[4]
+
+                tri6_mask = etypes == 4
+                semi_tri6_mask = (cells[cells_insert_ind] == 3) & tri6_mask
+                vtk_cell_type[semi_tri6_mask] = VTK_LINEAR_MAPPING[4]
             # Update cells with the mask
             cells = cells[mask]
 

--- a/src/ansys/dpf/core/vtk_helper.py
+++ b/src/ansys/dpf/core/vtk_helper.py
@@ -171,7 +171,7 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
         Meshed Region to export to pyVista format
 
     nodes : dpf.Field
-        Field containing the nodes of the mesh.
+        Field containing the node coordinates of the mesh.
 
     as_linear : bool
         Export quadratic surface elements as linear.
@@ -184,9 +184,9 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
     etypes = mesh.elements.element_types_field.data
     connectivity = mesh.elements.connectivities_field
     if nodes is None:
-        nodes = mesh.nodes.coordinates_field.data
+        node_coordinates = mesh.nodes.coordinates_field.data
     else:
-        nodes = nodes.data
+        node_coordinates = nodes.data
 
     elem_size = np.ediff1d(np.append(connectivity._data_pointer, connectivity.shape))
 
@@ -204,9 +204,12 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
 
     # Handle semiparabolic elements
     nullmask = connectivity.data == -1
-    connectivity.data[nullmask] = 0
+    # connectivity.data[nullmask] = 0
+    # if nullmask.any():
+    #     nodes[0] = np.nan
     if nullmask.any():
-        nodes[0] = np.nan
+        repeated_data_pointers = connectivity._data_pointer.repeat(repeats=elem_size)
+        connectivity.data[nullmask] = connectivity.data[repeated_data_pointers[nullmask]]
 
     # For each polyhedron, cell = [nCellFaces, nFace0pts, i, j, k, ..., nFace1pts, i, j, k, ...]
     # polys_ind = insert_ind[polyhedron_mask]
@@ -217,7 +220,7 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
     # Check if polyhedrons are present
     if element_types.Polyhedron.value in etypes:
         cells = np.array(cells)
-        nodes = np.array(nodes)
+        nodes = np.array(node_coordinates)
         insert_ind = insert_ind + np.asarray(list(range(len(insert_ind))))
         # Replace in cells values for polyhedron format
         # [NValuesToFollow,
@@ -249,6 +252,7 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
 
     # convert kAns to VTK cell type
     offset = None
+    as_linear = False
     if as_linear:
         vtk_cell_type = VTK_LINEAR_MAPPING[etypes]
 
@@ -256,7 +260,7 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
         ansquad8_mask = etypes == 6
         if np.any(ansquad8_mask):  # kAnsQuad8
 
-            # simply copy the edge node indices to the midside points
+            # simply copy the edge node indices to the mid-side points
             offset = compute_offset()
             cell_pos = offset[ansquad8_mask]
             cells[cell_pos + 5] = cells[cell_pos + 1]
@@ -275,17 +279,22 @@ def dpf_mesh_to_vtk_py(mesh, nodes, as_linear):
 
     else:
         vtk_cell_type = VTK_MAPPING[etypes]
+        # visualization bug within VTK with quadratic surf cells
+        ansquad8_mask = etypes == 6
+        if np.any(ansquad8_mask):  # kAnsQuad8
+            pass
 
     # different treatment depending on the version of vtk
     if VTK9:
         # compute offset array when < VTK v9
-        return pv.UnstructuredGrid(cells, vtk_cell_type, nodes)
+        grid = pv.UnstructuredGrid(cells, vtk_cell_type, node_coordinates)
+        return grid
 
     # might be computed when checking for VTK quadratic bug
     if offset is None:
         offset = compute_offset()
 
-    return pv.UnstructuredGrid(offset, cells, vtk_cell_type, nodes)
+    return pv.UnstructuredGrid(offset, cells, vtk_cell_type, node_coordinates)
 
 
 def dpf_mesh_to_vtk(mesh, nodes=None, as_linear=True):

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -52,6 +52,7 @@ def test_mesh_bare_plot(multishells):
     model = core.Model(multishells)
     mesh = model.metadata.meshed_region
     mesh.plot()
+    mesh.plot(as_linear=False)
 
 
 @pytest.mark.skipif(not HAS_PYVISTA, reason="Please install pyvista")


### PR DESCRIPTION
- [x] exposes `as_linear` argument in plot helpers
- [ ] hide internal edges of quadratic elements -> this is actually quite difficult to achieve as there is no direct way to trigger this using PyVista https://github.com/pyvista/pyvista/issues/867
