### PR TITLE
Fix imageio==2.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,14 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "ansys-dpf-gate>=0.3.*",
+    "imageio < 2.28.1",
     "importlib-metadata >=4.0",
-    "psutil",
+    "numpy",
     "packaging",
+    "psutil",
     "setuptools",
     "tqdm",
-    "numpy",
-    "ansys-dpf-gate>=0.3.*",
 ]
 
 [project.optional-dependencies]

--- a/requirements/requirements_install.txt
+++ b/requirements/requirements_install.txt
@@ -1,5 +1,8 @@
 ansys-dpf-gate==0.3.1
+imageio==2.28.0
+importlib-metadata==6.6.0
 numpy==1.24.1
 packaging==23.0
 psutil==5.9.4
+setuptools==67.7.2
 tqdm==4.64.1


### PR DESCRIPTION
Soves #931 

TLDR; `imageio==2.28.1` was released on May 3rd and is breaking our pipelines due to a deprecated keyword. Probably is an issue due to us restricting to `pyvista==0.36.1` in our pipelines due to issues with #930, since we do not call `imageio` anywhere directly.

https://github.com/pyansys/pydpf-core/actions/runs/4873975133/jobs/8694305801#step:8:309