### PR TITLE
Added method exposing operator_as_input connection

### DIFF
--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -267,6 +267,18 @@ class Operator:
             errormsg = f"input type {inpt.__class__} cannot be connected"
             raise TypeError(errormsg)
 
+    @version_requires("6.0")
+    def connect_operator_as_input(self, pin, op):
+        """Connects an operator as an input on a pin.
+        Parameters
+        ----------
+        pin : int
+            Number of the output pin. The default is ``0``.
+        op : :class:`ansys.dpf.core.dpf_operator.Operator`
+            Requested type of the output. The default is ``None``.
+        """
+        self._api.operator_connect_operator_as_input(self, pin, op)
+
     @property
     def _type_to_output_method(self):
         from ansys.dpf.core import (

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -260,6 +260,21 @@ def test_connect_operator_output_operator(server_type):
     assert len(fOut.data) == 3
 
 
+def test_connect_operator_as_input(server_type):
+    op_for_each = dpf.core.Operator("for_each", server=server_type)
+    fieldify = dpf.core.Operator("fieldify", server=server_type)
+    op_merge = dpf.core.Operator("incremental::merge::field", server=server_type)
+
+    op_for_each.connect_operator_as_input(0, fieldify)
+    op_for_each.connect(1, [1.0, 2.0, 3.0, 4.0])
+    op_for_each.connect(3, op_merge, 0)
+    op_merge.connect(0, fieldify, 0)
+    op_merge.connect(-2, True)
+
+    op_for_each.run()
+    assert op_for_each.get_output(3, dpf.core.types.field).get_entity_data(0) == 10.0
+
+
 def test_eval_operator(server_type):
     op = dpf.core.Operator("min_max", server=server_type)
     inpt = dpf.core.Field(nentities=3, server=server_type)


### PR DESCRIPTION
This new method finalizes the implementation of operator_connect_operator_as_input which was previously only available from the C API, and is now available from the gRPC API.

