### PR TITLE
Remove pipelines warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: "Setup Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: "Setup Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Set up Python"
-        uses: actions/setup-python@v4.1.0
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: 3.9
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,7 +87,7 @@ jobs:
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -92,7 +92,7 @@ jobs:
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/examples_docker.yml
+++ b/.github/workflows/examples_docker.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -72,7 +72,7 @@ jobs:
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -79,7 +79,7 @@ jobs:
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
       - name: "Setup Python"
-        uses: actions/setup-python@v2.1.4
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: "3.8"
 
@@ -146,14 +146,8 @@ jobs:
         shell: bash
         working-directory: pydpf-post/tests
         run: |
-          pytest $DEBUG --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results-post.xml --reruns 2 .
+          pytest $DEBUG --reruns 2 .
         if: always()
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
-
-      - name: "Upload Test Results"
-        uses: actions/upload-artifact@v2
-        with:
-          name: ansys-dpf-post_pytest
-          path: pydpf-post/tests/junit/test-results-post.xml

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -99,7 +99,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=junit/test-results.xml tests/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results.xml tests/.
 
       - name: "Test API test_launcher"
         uses: nick-fields/retry@v2
@@ -108,7 +108,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results2.xml test_launcher/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results2.xml test_launcher/.
 
       - name: "Test API test_server"
         uses: nick-fields/retry@v2
@@ -117,7 +117,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results3.xml test_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results3.xml test_server/.
 
       - name: "Test API test_local_server"
         uses: nick-fields/retry@v2
@@ -126,7 +126,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results4.xml test_local_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results4.xml test_local_server/.
 
       - name: "Test API test_multi_server"
         uses: nick-fields/retry@v2
@@ -135,7 +135,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results5.xml test_multi_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results5.xml test_multi_server/.
 
       - name: "Test API test_remote_workflow"
         uses: nick-fields/retry@v2
@@ -144,7 +144,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results6.xml test_remote_workflow/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results6.xml test_remote_workflow/.
 
       - name: "Test API test_remote_operator"
         uses: nick-fields/retry@v2
@@ -153,7 +153,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results7.xml test_remote_operator/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results7.xml test_remote_operator/.
 
       - name: "Test API test_workflow"
         uses: nick-fields/retry@v2
@@ -162,7 +162,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results8.xml test_workflow/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results8.xml test_workflow/.
 
       - name: "Test API test_service"
         uses: nick-fields/retry@v2
@@ -171,14 +171,14 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results9.xml test_service/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results9.xml test_service/.
 
       - name: "Test API Entry"
         shell: bash
         working-directory: tests
         run: |
           cd entry
-          pytest $DEBUG $COVERAGE $RERUNS --junitxml=../junit/test-results10.xml  .
+          pytest $DEBUG $COVERAGE $RERUNS --junitxml=junit/test-results10.xml  .
         if: always()
         timeout-minutes: 10
 

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -89,7 +89,7 @@ jobs:
       - name: "Set pytest arguments"
         shell: bash
         run: |
-          echo "COVERAGE=--cov=ansys.dpf.${{env.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR" >> $GITHUB_ENV
+          echo "COVERAGE=--cov=ansys.dpf.${{env.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR --cov-append" >> $GITHUB_ENV
           echo "RERUNS=--reruns 2 --reruns-delay 1" >> $GITHUB_ENV
 
       - name: "Test API"
@@ -99,7 +99,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results.xml tests/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=junit/test-results.xml tests/.
 
       - name: "Test API test_launcher"
         uses: nick-fields/retry@v2
@@ -108,7 +108,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results2.xml test_launcher/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results2.xml test_launcher/.
 
       - name: "Test API test_server"
         uses: nick-fields/retry@v2
@@ -117,7 +117,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results3.xml test_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results3.xml test_server/.
 
       - name: "Test API test_local_server"
         uses: nick-fields/retry@v2
@@ -126,7 +126,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results4.xml test_local_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results4.xml test_local_server/.
 
       - name: "Test API test_multi_server"
         uses: nick-fields/retry@v2
@@ -135,7 +135,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results5.xml test_multi_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results5.xml test_multi_server/.
 
       - name: "Test API test_remote_workflow"
         uses: nick-fields/retry@v2
@@ -144,7 +144,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results6.xml test_remote_workflow/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results6.xml test_remote_workflow/.
 
       - name: "Test API test_remote_operator"
         uses: nick-fields/retry@v2
@@ -153,7 +153,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results7.xml test_remote_operator/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results7.xml test_remote_operator/.
 
       - name: "Test API test_workflow"
         uses: nick-fields/retry@v2
@@ -162,7 +162,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results8.xml test_workflow/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results8.xml test_workflow/.
 
       - name: "Test API test_service"
         uses: nick-fields/retry@v2
@@ -171,14 +171,14 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results9.xml test_service/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results9.xml test_service/.
 
       - name: "Test API Entry"
         shell: bash
         working-directory: tests
         run: |
           cd entry
-          pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=junit/test-results10.xml  .
+          pytest $DEBUG $COVERAGE $RERUNS --junitxml=../junit/test-results10.xml  .
         if: always()
         timeout-minutes: 10
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
       - name: "Set pytest arguments"
         shell: bash
         run: |
-          echo "COVERAGE=--cov=ansys.dpf.${{env.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR" >> $GITHUB_ENV
+          echo "COVERAGE=--cov=ansys.dpf.${{env.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR --cov-append" >> $GITHUB_ENV
           echo "RERUNS=--reruns 2 --reruns-delay 1" >> $GITHUB_ENV
 
       - name: "Test API"
@@ -186,7 +186,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results2.xml test_launcher/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results2.xml test_launcher/.
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
@@ -199,7 +199,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results3.xml test_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results3.xml test_server/.
         if: always()
 
       - name: "Kill all servers"
@@ -213,7 +213,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results4.xml test_local_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results4.xml test_local_server/.
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
@@ -226,7 +226,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results5.xml test_multi_server/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results5.xml test_multi_server/.
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
@@ -239,7 +239,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results6.xml test_remote_workflow/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results6.xml test_remote_workflow/.
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
@@ -249,7 +249,7 @@ jobs:
         shell: bash
         working-directory: test_remote_operator
         run: |
-          pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results7.xml .
+          pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results7.xml .
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
@@ -263,7 +263,7 @@ jobs:
           retry_wait_seconds: 15
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results8.xml test_workflow/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=../tests/junit/test-results8.xml test_workflow/.
         if: always()
 
       - name: "Kill all servers"
@@ -277,7 +277,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=tests/junit/test-results9.xml test_service/.
+            pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results9.xml test_service/.
 
       - name: "Kill all servers"
         uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
@@ -288,7 +288,7 @@ jobs:
         working-directory: tests
         run: |
           cd entry
-          pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=junit/test-results10.xml  .
+          pytest $DEBUG $COVERAGE $RERUNS --junitxml=../junit/test-results10.xml  .
         if: always()
         timeout-minutes: 30
 

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
Bumps version of actions when deprecated warning was raised
Corrects paths to coverage files not found