### PR TITLE
Transfer full homogeneity responsability to the server

### DIFF
--- a/src/ansys/dpf/core/available_result.py
+++ b/src/ansys/dpf/core/available_result.py
@@ -219,7 +219,7 @@ class AvailableResult:
             op = dpf.Operator("homogeneity_name")
             op.connect(0, self._homogeneity)
             return op.get_output(0, dpf.types.string)
-        except (dpf.errors.KeyError, dpf.errors.DPFServerException):
+        except (KeyError, dpf.errors.DPFServerException):
             try:
                 return Homogeneity(self._homogeneity).name
             except ValueError as exception:


### PR DESCRIPTION
To avoid code duplication and enhance maintainability, the `Homogeneity` Enum is retired (it is left for backwards compatibility), and the translation from Homogeneity id to string is now done server-side through the `homogeneity_string` operator.