### PR TITLE
ci(tests): Add parallel_show_output=True to test environments in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,8 @@ pass_env =
 deps = 
     -r requirements/requirements_test.txt
 
+parallel_show_output = True
+
 [testenv:build-wheel]
 description = Environment for custom build of package wheels
 


### PR DESCRIPTION
This means that test steps will always show the list of tests which passed in parallel Tox environments, even if all are successful.