### PR TITLE
fix(dependencies): expired deprecation for conversion of np.inexact to dtype in numpy 2.3.0

### DIFF
--- a/src/ansys/dpf/core/geometry.py
+++ b/src/ansys/dpf/core/geometry.py
@@ -154,7 +154,7 @@ class Line:
     def __init__(self, coordinates, n_points=100, server=None):
         """Initialize line object from two 3D points and discretize."""
         if not isinstance(coordinates, Field):
-            coordinates = np.asarray(coordinates, dtype=np.number)
+            coordinates = np.asarray(coordinates, dtype=np.float64)
             coordinates = field_from_array(coordinates)
         if not len(coordinates.data) == 2:
             raise ValueError("Only two points must be introduced to define a line")


### PR DESCRIPTION
Fixes #2356 

See https://numpy.org/doc/stable/user/basics.types.html#array-types-and-conversions-between-types
