### PR TITLE
test(any): fix skip criterion for test_cast_data_sources_any

### DIFF
--- a/tests/test_any.py
+++ b/tests/test_any.py
@@ -123,8 +123,8 @@ def test_cast_scoping_any(server_type):
 
 
 @pytest.mark.skipif(
-    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0,
-    reason="Requires 24R2.",
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0,
+    reason="Requires 26R1.",
 )
 def test_cast_data_sources_any(server_type):
     # Not available through grpc yet


### PR DESCRIPTION
The `any` wheel of PyDPF-Core does not allow cast of Any to/from a data sources for DPF 252 and below as it does not ship the latest DPFClientAPI.
This is blocking the release pipeline which tests the `any` wheel against 252.
https://github.com/ansys/pydpf-core/actions/runs/16798597515/job/47574420315#step:21:2024

Effect on the release CI:
https://github.com/ansys/pydpf-core/actions/runs/16799321037