### PR TITLE
Fix test after addition of Rotation result

### DIFF
--- a/examples/05-file-IO/02-hdf5_serialize_and_read.py
+++ b/examples/05-file-IO/02-hdf5_serialize_and_read.py
@@ -172,11 +172,15 @@ mesh_deser_set_per_set.plot(res_deser_set_per_set_list[num_res * 1 + 0])
 position_result = result_names_on_all_time_steps.index("result_ENF")
 to_nodal_op = dpf.operators.averaging.to_nodal_fc()
 
-fc_all_steps_first_step_first_res = res_deser_all_times_list[position_result].get_field_by_time_id(6)  # set 6
+fc_all_steps_first_step_first_res = res_deser_all_times_list[position_result].get_field_by_time_id(
+    6
+)  # set 6
 mesh_deser_all_times.plot(
     dpf.operators.averaging.to_nodal(fc_all_steps_first_step_first_res).outputs.field()
 )
 
 mesh_deser_set_per_set.plot(
-    dpf.operators.averaging.to_nodal(res_deser_set_per_set_list[num_res * 5 + position_result]).outputs.field()
+    dpf.operators.averaging.to_nodal(
+        res_deser_set_per_set_list[num_res * 5 + position_result]
+    ).outputs.field()
 )


### PR DESCRIPTION
After the addition of rotation result to available results, the position of ENF result got shifted from 3rd position to 4th for the test:02-hdf5_serialize_and_read. This made the comparison happen on a different result which caused an error.

This PR changes the test so that we always look at the result ENF no matter its position on the result info.