### PR TITLE
ci(pydpf-post): fix step to get latest version

### DIFF
--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -122,7 +122,7 @@ jobs:
           echo branch="$BranchName"
           if [ "$BranchName" = '' ];
           then
-              BranchName=$(git ls-remote --tags --refs $REPO | tail -n1 | cut -d/ -f3)
+              BranchName=$(git ls-remote --tags --sort="v:refname" --refs $REPO | tail -n1 | cut -d/ -f3)
           fi
           echo branch=$BranchName
           git clone --single-branch --branch "$BranchName" $REPO


### PR DESCRIPTION
Fixes the logic to get the latest released version ref of the PyDPF-Post repository. 