### PR TITLE
fix: fix Field.data for LegacyGrpcServer

### DIFF
--- a/src/ansys/dpf/gate/dpf_vector.py
+++ b/src/ansys/dpf/gate/dpf_vector.py
@@ -45,7 +45,7 @@ class DPFVectorBase:
             if not server_meet_version("4.1",
                                        owner._server) and owner._server.client is None:  # BUG in 22.2: DpfVector is not holding the data owner and not call to data owner should be done at delete
                 self._modified = False
-        except ctypes.ArgumentError:
+        except (ctypes.ArgumentError, AttributeError):
             raise NotImplementedError
 
     @property


### PR DESCRIPTION
A script using only a `LegacyGrpcServer` would raise an `AttributeError` in `Field._get_data` when trying to create a `DPFVectorDouble`.
This error type was no longer caught in #2141 