### PR TITLE
doc(docstring): fix docstring example of LicenseContextManager

### DIFF
--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -118,6 +118,7 @@ class LicenseContextManager:
     Examples
     --------
     Using a context manager
+
     >>> from ansys.dpf import core as dpf
     >>> dpf.set_default_server_context(dpf.AvailableServerContexts.premium)
     >>> field = dpf.Field()
@@ -129,6 +130,7 @@ class LicenseContextManager:
     ...    out = op.outputs.field()
 
     Using an instance
+
     >>> lic = dpf.LicenseContextManager()
     >>> op.inputs.field(field)
     >>> op.inputs.threshold(0.0)
@@ -136,6 +138,7 @@ class LicenseContextManager:
     >>> lic = None
 
     Using a context manager and choosing license options
+
     >>> op.inputs.field(field)
     >>> op.inputs.threshold(0.0)
     >>> out = op.outputs.field()
@@ -149,6 +152,7 @@ class LicenseContextManager:
     Notes
     -----
     Available from 6.1 server version.
+
     """
 
     def __init__(


### PR DESCRIPTION
Fixes the rendering of the example in the docstring of `LicenseContextManager`:

<img width="1113" height="828" alt="image" src="https://github.com/user-attachments/assets/b795d719-0468-4872-9ff7-9a7ac705202a" />
