### PR TITLE
ci(doc): Switch to using the Any wheel for doc generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,7 +79,7 @@ jobs:
       - name: "Build the wheel"
         shell: pwsh
         run: |
-          tox -e build-wheel
+          tox -e build-wheel -- "any"
 
       - name: "Expose the wheel"
         shell: bash


### PR DESCRIPTION
 to bypass current issues with `FLPRJ` examples during doc generation for 252 due to gatebin.