### PR TITLE
feat: add DataSources.streams_container

### DIFF
--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -701,6 +701,21 @@ class DataSources:
         """
         return self._api.data_sources_get_namespace(self, result_key)
 
+    @property
+    def streams_container(self) -> dpf.StreamsContainer:
+        """Get the streams container representation of the data sources.
+
+        .. warning:: Only available with an InProcess server.
+
+        Returns
+        -------
+        streams_container:
+            StreamsContainer representation of the data sources.
+        """
+        from ansys.dpf.core.operators.metadata.streams_provider import streams_provider
+
+        return streams_provider(data_sources=self, server=self._server).outputs.streams_container()
+
     def __str__(self):
         """Describe the entity.
 

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -185,3 +185,10 @@ def test_namespace(allkindofcomplexity, server_type):
     data_sources = dpf.core.DataSources(server=server_type)
     data_sources.set_result_file_path(cas_h5_file)
     assert data_sources.namespace(data_sources.result_key) == "cff"
+
+
+def test_as_stream(allkindofcomplexity, server_in_process):
+    ds = dpf.core.DataSources(allkindofcomplexity, server=server_in_process)
+    stream = ds.streams_container
+    assert isinstance(stream, dpf.core.StreamsContainer)
+    assert stream.datasources.result_files == ds.result_files


### PR DESCRIPTION
This is a small helper to quickly build a `StreamsContainer` from a `DataSources`.