### PR TITLE
ci(test): Test docstrings against latest released DPF in the dev pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,11 +198,15 @@ jobs:
       matrix:
         version:
           - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO_WITH_PATCH) }}
-          - ${{ fromJson(vars.ANSYS_VERSION_LAST_RELEASED_WITH_PATCH) }}
+        docstring:
+          - "false"
+        include:
+          - version: ${{ fromJson(vars.ANSYS_VERSION_LAST_RELEASED_WITH_PATCH) }}
+            docstring: "true"
     uses: ./.github/workflows/tests.yml
     with:
       ANSYS_VERSION: ${{ matrix.version.version }}
       python_versions: '["3.10"]'
-      DOCSTRING: false
+      DOCSTRING: ${{ matrix.docstring }}
       standalone_suffix: ${{ matrix.version.patch }}
     secrets: inherit


### PR DESCRIPTION
This will prevent only noticing retro-compatibility issues in docstrings when running the release CI.