### PR TITLE
fix(server): fix the dpf install selection logic when ansys-dpf-core is shipped within an Ansys installation

### DIFF
--- a/src/ansys/dpf/core/misc.py
+++ b/src/ansys/dpf/core/misc.py
@@ -112,12 +112,16 @@ def get_ansys_path(ansys_path=None):
     if ansys_path is None:
         current_file = Path(__file__).resolve()
         path_parts = current_file.parts
-        ansys_inc_part = str(Path("ANSYS Inc") / "v")
+        if os.name == "posix":
+            ansys_inc_str = "ansys_inc"
+        else:
+            ansys_inc_str = "ANSYS Inc"
+        ansys_inc_part = str(Path(ansys_inc_str) / "v")
         commonfiles_interpreter_part = str(Path("commonfiles") / "CPython")
         if ansys_inc_part in str(current_file) and commonfiles_interpreter_part in str(
             current_file
         ):
-            ansys_index = path_parts.index("ANSYS Inc")
+            ansys_index = path_parts.index(ansys_inc_str)
             possible_ansys_path = Path(*path_parts[: ansys_index + 2])
             if possible_ansys_path.is_dir():
                 ansys_path = str(possible_ansys_path)


### PR DESCRIPTION
closes #2768 