### PR TITLE
test(doctest): loosen requirements on expected spec prints

### DIFF
--- a/src/ansys/dpf/core/operator_specification.py
+++ b/src/ansys/dpf/core/operator_specification.py
@@ -334,7 +334,7 @@ class Specification(SpecificationBase):
         >>> from ansys.dpf import core as dpf
         >>> operator = dpf.operators.math.add()
         >>> operator.specification.properties
-        {'category': 'math', 'exposure': 'public', 'plugin': 'core', 'user_name': '+'}
+        {'category': '...', 'exposure': '...', 'plugin': '...', 'user_name': '...'}
         """
         if self._properties is None:
             temp_properties = dict()
@@ -386,8 +386,8 @@ class Specification(SpecificationBase):
         >>> 4 in operator.specification.inputs.keys()
         True
         >>> operator.specification.inputs[4]
-        PinSpecification(name='data_sources', _type_names=['data_sources'], ...set', ellipsis=False,
-         name_derived_class='', aliases=[...])
+        PinSpecification(name='...', _type_names=[...], ...,
+         name_derived_class=..., aliases=[...])
         """
         if self._map_input_pin_spec is None:
             self._map_input_pin_spec = {}
@@ -407,8 +407,8 @@ class Specification(SpecificationBase):
         >>> from ansys.dpf import core as dpf
         >>> operator = dpf.operators.mesh.mesh_provider()
         >>> operator.specification.outputs
-        {0: PinSpecification(name='mesh', _type_names=['abstract_meshed_region'], ...=False,
-         name_derived_class='', aliases=[...])}
+        {0: PinSpecification(name='...', _type_names=[...], ...,
+         name_derived_class=..., aliases=[...])}
         """
         if self._map_output_pin_spec is None:
             self._map_output_pin_spec = {}


### PR DESCRIPTION
Current work on improvements to operator specification descriptions means we now encounter a lot of doctest errors due to too restrictive acceptance criteria on complete string representations. (see example [here](https://github.com/ansys/pydpf-core/actions/runs/19828253134/job/56807255961?pr=2789#step:17:342))
This PR loosens such requirements for the doctests in the `operator_specification.py` module.