### PR TITLE
dependencies(Python): drop support for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-dpf-core"
 version = "0.15.1.dev0"
 description = "Data Processing Framework - Python Core "
 readme = "README.md"
-requires-python = ">=3.9, <4"
+requires-python = ">=3.10, <4"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},


### PR DESCRIPTION
Following #2880 , we need to explicitly drop support for Python 3.9 as we now depend on `ansys-tools-common` which requires `Python>=3.10`.