### PR TITLE
fix(vtk): use auto tolerance for convexity check of polyhedron cells

### DIFF
--- a/src/ansys/dpf/core/vtk_helper.py
+++ b/src/ansys/dpf/core/vtk_helper.py
@@ -497,6 +497,9 @@ def vtk_mesh_is_valid(grid: pv.UnstructuredGrid, verbose: bool = False) -> VTKMe
 
     # Run the cell validator
     cell_validator = vtkCellValidator()
+    # For VTK 9.5.3 and above, use auto tolerance for polyhedron convexity testing
+    if hasattr(cell_validator, "AutoToleranceOn"):  # pragma: nocover
+        cell_validator.AutoToleranceOn()
     cell_validator.SetInputData(grid)
     cell_validator.Update()
     # Get the states for all cells as a numpy array


### PR DESCRIPTION
This PR prepares the arrival of a new auto-tolerance feature for checking convexity of polyhedral elements with VTK 9.5.3+.
This fixes some issues we currently have with polyhedral fluid mesh validation where false positive were detected.