### PR TITLE
fix(warnings): fix warning during deletion of GrpcClient

### DIFF
--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -774,6 +774,8 @@ class CServer(BaseServer, ABC):
 class GrpcClient:
     """Client using the gRPC communication protocol."""
 
+    _internal_obj = None
+
     def __init__(self):
         from ansys.dpf.gate import client_capi
 


### PR DESCRIPTION
Deletion of the GrpcClient due to failure to initialize resulted in a useless and distracting warning about `_internal_obj`. 