### PR TITLE
feat(doc): update the operator doc template for pins and configs

### DIFF
--- a/src/ansys/dpf/core/documentation/operator_doc_template.j2
+++ b/src/ansys/dpf/core/documentation/operator_doc_template.j2
@@ -20,20 +20,15 @@ This operator supports the following keys ([file formats](../../index.md#overvie
 {% endif %}
 ## Inputs
 
-.. list-table:: **Input pins summary**
-   :header-rows: 1
-   :widths: 10 20 20
-
-   * - Pin
-     - Name
-     - Type(s)
-{% for input in inputs %}
-   * - {{ input.pin_number }}
-     - {{ input.name }}
-     - {% for t in input.types -%}{% if '::' in t or t in ['materials_container','materials','binary_operation_enum','umap<int32,int32>','stream','vector<shared_ptr<any_collection>>','vector<shared_ptr<field>>','umap<string,shared_ptr<abstract_field_support>>','vector<shared_ptr<abstract_meshed_region>>','vector<shared_ptr<materials>>','ans_dispatch_holder','struct IAnsDispatch','abstract_field_support','vector<shared_ptr<fields_container>>','vector<shared_ptr<data_tree>>','vector<shared_ptr<generic_data_container>>','vector<shared_ptr<time_freq_support>>','mesh_selection_manager','vector<shared_ptr<abstract_field_support>>','vector<shared_ptr<string_field>>','vector<shared_ptr<scopings_container>>','vector<shared_ptr<scoping>>','vector<shared_ptr<result_info>>','vector<shared_ptr<meshes_container>>','vector<shared_ptr<property_field>>'] %}`{{ t }}`{% elif t in ['int32','bool','char','double','string','uint32','uint64','vector<int32>','vector<bool>','vector<char>','vector<double>','vector<string>','vector<float>'] %}`{{ t }}`{% elif t.startswith('abstract_') %}`{{ t }}`{% else %}`{{ t }}`{% endif %}{% if not loop.last %}, {% endif %}{%- endfor %}
-{% endfor %}
+| Pin number | Name | Expected type(s) |
+|-------|-------|------------------|
+{%- for input in inputs %}
+| {% if not input.optional %}<strong>{{ input.pin_number }}</strong> <span style="background-color:#d93025; color:white; padding:2px 6px; border-radius:3px; font-size:0.75em;">Required</span>{% else %}<strong>{{ input.pin_number }}</strong>{% endif %}|  [{{ input.name }}](#input_{{ input.pin_number }}) |
+{%- for t in input.types -%}{% if "::" in t or t == "materials_container" or t == "materials" or t == "binary_operation_enum" or t == "umap<int32,int32>" or t == "stream" or t == "vector<shared_ptr<any_collection>>" or t == "vector<shared_ptr<field>>" or t == "umap<string,shared_ptr<abstract_field_support>>" or t == "vector<shared_ptr<abstract_meshed_region>>" or t == "vector<shared_ptr<materials>>" or t == "ans_dispatch_holder" or t == "struct IAnsDispatch" or t == "abstract_field_support" or t == "vector<shared_ptr<fields_container>>" or t == "vector<shared_ptr<data_tree>>" or t == "vector<shared_ptr<generic_data_container>>" or t == "vector<shared_ptr<time_freq_support>>" or t == "mesh_selection_manager" or t == "vector<shared_ptr<abstract_field_support>>" or t == "vector<shared_ptr<string_field>>" or t == "vector<shared_ptr<scopings_container>>" or t == "vector<shared_ptr<scoping>>" or t == "vector<shared_ptr<result_info>>" or t == "vector<shared_ptr<meshes_container>>" or t == "vector<shared_ptr<property_field>>" %}`{{ t }}`{% elif t == "int32" or t == "bool" or t == "char" or t == "double" or t == "string" or t == "uint32" or t == "uint64" or t == "vector<int32>" or t == "vector<bool>" or t == "vector<char>" or t == "vector<double>" or t == "vector<string>" or t == "vector<float>" %}[`{{ t }}`](../../core-concepts/dpf-types.md#standard-types){% elif t.startswith("abstract_") %}[`{{ t }}`](../../core-concepts/dpf-types.md#{{ t | replace("abstract_", "") | replace("_", "-") | replace (" ", "-") | lower}}){% else %}[`{{ t }}`](../../core-concepts/dpf-types.md#{{ t | replace("_", "-") | replace(" ", "-") | lower}}){% endif %}{% if not loop.last %}, {% endif %}{%- endfor %} |
+{%- endfor %}
 
 {% for input in inputs %}
+<a id="input_{{ input.pin_number }}"></a>
 ### {{ input.name }} (Pin {{ input.pin_number }})
 
 - **Required:** {{ 'Yes' if not input.optional else 'No' }}
@@ -44,20 +39,15 @@ This operator supports the following keys ([file formats](../../index.md#overvie
 
 ## Outputs
 
-.. list-table:: **Output pins summary**
-   :header-rows: 1
-   :widths: 10 20 20
-
-   * - Pin
-     - Name
-     - Type(s)
-{% for output in outputs %}
-   * - {{ output.pin_number }}
-     - {{ output.name }}
-     - {% for t in output.types -%}{% if '::' in t or t in ['materials_container','materials','binary_operation_enum','umap<int32,int32>','stream','vector<shared_ptr<any_collection>>','vector<shared_ptr<field>>','umap<string,shared_ptr<abstract_field_support>>','vector<shared_ptr<abstract_meshed_region>>','vector<shared_ptr<materials>>','ans_dispatch_holder','struct IAnsDispatch','abstract_field_support','vector<shared_ptr<fields_container>>','vector<shared_ptr<data_tree>>','vector<shared_ptr<generic_data_container>>','vector<shared_ptr<time_freq_support>>','mesh_selection_manager','vector<shared_ptr<abstract_field_support>>','vector<shared_ptr<string_field>>','vector<shared_ptr<scopings_container>>','vector<shared_ptr<scoping>>','vector<shared_ptr<result_info>>','vector<shared_ptr<meshes_container>>','vector<shared_ptr<property_field>>'] %}`{{ t }}`{% elif t in ['int32','bool','char','double','string','uint32','uint64','vector<int32>','vector<bool>','vector<char>','vector<double>','vector<string>','vector<float>'] %}`{{ t }}`{% elif t.startswith('abstract_') %}`{{ t }}`{% else %}`{{ t }}`{% endif %}{% if not loop.last %}, {% endif %}{%- endfor %}
-{% endfor %}
+| Pin number |  Name | Expected type(s) |
+|-------|------|------------------|
+{%- for output in outputs %}
+|  **{{ output.pin_number }}**| [{{ output.name }}](#output_{{ output.pin_number }}) |
+{%- for t in output.types -%}{% if "::" in t or t == "materials_container" or t == "materials" or t == "binary_operation_enum" or t == "umap<int32,int32>" or t == "stream" or t == "vector<shared_ptr<any_collection>>" or t == "vector<shared_ptr<field>>" or t == "umap<string,shared_ptr<abstract_field_support>>" or t == "vector<shared_ptr<abstract_meshed_region>>" or t == "vector<shared_ptr<materials>>" or t == "ans_dispatch_holder" or t == "struct IAnsDispatch" or t == "abstract_field_support" or t == "vector<shared_ptr<fields_container>>" or t == "vector<shared_ptr<data_tree>>" or t == "vector<shared_ptr<generic_data_container>>" or t == "vector<shared_ptr<time_freq_support>>" or t == "mesh_selection_manager" or t == "vector<shared_ptr<abstract_field_support>>" or t == "vector<shared_ptr<string_field>>" or t == "vector<shared_ptr<scopings_container>>" or t == "vector<shared_ptr<scoping>>" or t == "vector<shared_ptr<result_info>>" or t == "vector<shared_ptr<meshes_container>>" or t == "vector<shared_ptr<property_field>>" %}`{{ t }}`{% elif t == "int32" or t == "bool" or t == "char" or t == "double" or t == "string" or t == "uint32" or t == "uint64" or t == "vector<int32>" or t == "vector<bool>" or t == "vector<char>" or t == "vector<double>" or t == "vector<string>" or t == "vector<float>" %}[`{{ t }}`](../../core-concepts/dpf-types.md#standard-types){% elif t.startswith("abstract_") %}[`{{ t }}`](../../core-concepts/dpf-types.md#{{ t | replace("abstract_", "") | replace("_", "-") | replace (" ", "-") | lower}}){% else %}[`{{ t }}`](../../core-concepts/dpf-types.md#{{ t | replace("_", "-") | replace(" ", "-") | lower}}){% endif %}{% if not loop.last %}, {% endif %}{%- endfor %} |
+{%- endfor %}
 
 {% for output in outputs %}
+<a id="output_{{ output.pin_number }}"></a>
 ### {{ output.name }} (Pin {{ output.pin_number }})
 
 - **Expected type(s):** {% for t in output.types -%}{% if '::' in t or t in ['materials_container','materials','binary_operation_enum','umap<int32,int32>','stream','vector<shared_ptr<any_collection>>','vector<shared_ptr<field>>','umap<string,shared_ptr<abstract_field_support>>','vector<shared_ptr<abstract_meshed_region>>','vector<shared_ptr<materials>>','ans_dispatch_holder','struct IAnsDispatch','abstract_field_support','vector<shared_ptr<fields_container>>','vector<shared_ptr<data_tree>>','vector<shared_ptr/ generic_data_container>>','vector<shared_ptr<time_freq_support>>','mesh_selection_manager','vector<shared_ptr<abstract_field_support>>','vector<shared_ptr<string_field>>','vector<shared_ptr<scopings_container>>','vector<shared_ptr<scoping>>','vector<shared_ptr<result_info>>','vector<shared_ptr<meshes_container>>','vector<shared_ptr<property_field>>'] %}`{{ t }}`{% elif t in ['int32','bool','char','double','string','uint32','uint64','vector<int32>','vector<bool>','vector<char>','vector<double>','vector<string>','vector<float>'] %}[`{{ t }}`](../../core-concepts/dpf-types.md#standard-types){% elif t.startswith('abstract_') %}[`{{ t }}`](../../core-concepts/dpf-types.md#{{ t | replace('abstract_','') | replace('_','-') | replace(' ','-') | lower}}){% else %}[`{{ t }}`](../../core-concepts/dpf-types.md#{{ t | replace('_','-') | replace(' ','-') | lower}}){% endif %}{% if not loop.last %}, {% endif %}{%- endfor %}


### PR DESCRIPTION
The current implementation does not allow for a correct inclusion of markdown descriptions of pins (or configs) in the DevPortal DPF Framework documentation.

The issue lies with using markdown tables to list the pins and configs.
There is no solution to correctly include the markdown descriptions in tables, so this PR proposes to switch to a presentation of pins and configs using subsections, as well as automatically decreasing the level of included headers to correctly integrate with the rest of the template.
This has two big advantages:
- removes the need to define complicated rules about accepted markdown in operator descriptions, pin descriptions or config descriptions
- this allows to link directly to pins or configs when referencing the operator documentation since they are now sections

Disadvantages:
- this makes the doc page longer and requires to scroll through it, which changes the habit compared to the old operator doc.

This disadvantage could probably be negated using several tricks such as:
- collapsible descriptions?
- a short vs a long description

One remark already concerning long operator descriptions using Markdown is that they show up everywhere. It has already been said that we may want to provide a short vs a long description, maybe starting by taking the first line of the description as the "short description", and then everything as the "long description".

This would mimic behavior for docstrings in Python.