### PR TITLE
chore(example-data): update examples download url

### DIFF
--- a/src/ansys/dpf/core/examples/downloads.py
+++ b/src/ansys/dpf/core/examples/downloads.py
@@ -34,7 +34,7 @@ import warnings
 
 from ansys.dpf.core.examples.examples import find_files
 
-EXAMPLE_REPO = "https://github.com/ansys/example-data/blob/main/"
+EXAMPLE_REPO = "https://github.com/ansys/example-data/raw/main/"
 
 GITHUB_SOURCE_URL = (
     "https://github.com/ansys/pydpf-core/raw/"


### PR DESCRIPTION
To comply with the recent change of the default branch to main.