### PR TITLE
Avoid misc gate client config mock class

### DIFF
--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -923,7 +923,6 @@ class GrpcServer(CServer):
                 )
                 self._local_server = True
 
-        from ansys.dpf.core import settings
         client_config = settings.get_runtime_client_config(server=self)
 
         if self._grpc_mode == server_factory.GrpcMode.Insecure:


### PR DESCRIPTION
Temporarily passing the LocalClientConfig was wrongly initializing RuntimeclientConfig, and on the GrpcClient side, it would add grpc a metadata interceptor, resulting in an unexpected performance regression on all grpc requests.