### PR TITLE
chore: revert tox `v4.42.0` changes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -231,7 +231,7 @@ dependency_groups =
 commands_pre =
     # Clear any running servers that may be locking resources
     html,links: python -c "import psutil; proc_name = 'Ans.Dpf.Grpc'; nb_procs = len([proc.kill() for proc in psutil.process_iter() if proc_name in proc.name()]); \
-                print(f'Killed \{nb_procs} \{proc_name} processes.')"
+    html,links: print(f'Killed \{nb_procs} \{proc_name} processes.')"
 
 commands =
     # Remove previously rendered documentation
@@ -239,18 +239,18 @@ commands =
 
     # Clean examples from previous build
     clean: python -c "\
-           from os.path import exists; import shutil; \
-           [(shutil.rmtree(p) if exists(p) else None) for p in ['{env:SOURCE_DIR}/images/auto-generated']]; \
-           [(shutil.move(src, dst) if exists(src) else None) for src, dst in \
-           [('{env:SOURCE_DIR}/examples/07-python-operators/plugins', '{env:SOURCE_DIR}/_temp/plugins'), \
-           ('{env:SOURCE_DIR}/examples/04-advanced/02-volume_averaged_stress', '{env:SOURCE_DIR}/_temp/04_advanced'), \
-           ('{env:SOURCE_DIR}/examples/12-fluids/02-fluids_results', '{env:SOURCE_DIR}/_temp/12_fluids')]]; \
-           [shutil.rmtree(p) for p in ['{env:SOURCE_DIR}/examples'] if exists(p)]; \
-           [(shutil.move(src, dst) if exists(src) else None) for src, dst in \
-           [('{env:SOURCE_DIR}/_temp/plugins', '{env:SOURCE_DIR}/examples/07-python-operators/plugins'), \
-           ('{env:SOURCE_DIR}/_temp/04_advanced', '{env:SOURCE_DIR}/examples/04-advanced/02-volume_averaged_stress'), \
-           ('{env:SOURCE_DIR}/_temp/12_fluids', '{env:SOURCE_DIR}/examples/12-fluids/02-fluids_results')]]; \
-           [shutil.rmtree(p) for p in ['{env:SOURCE_DIR}/_temp'] if exists(p)]"
+    clean: from os.path import exists; import shutil; \
+    clean: [(shutil.rmtree(p) if exists(p) else None) for p in ['{env:SOURCE_DIR}/images/auto-generated']]; \
+    clean: [(shutil.move(src, dst) if exists(src) else None) for src, dst in \
+    clean: [('{env:SOURCE_DIR}/examples/07-python-operators/plugins', '{env:SOURCE_DIR}/_temp/plugins'), \
+    clean: ('{env:SOURCE_DIR}/examples/04-advanced/02-volume_averaged_stress', '{env:SOURCE_DIR}/_temp/04_advanced'), \
+    clean: ('{env:SOURCE_DIR}/examples/12-fluids/02-fluids_results', '{env:SOURCE_DIR}/_temp/12_fluids')]]; \
+    clean: [shutil.rmtree(p) for p in ['{env:SOURCE_DIR}/examples'] if exists(p)]; \
+    clean: [(shutil.move(src, dst) if exists(src) else None) for src, dst in \
+    clean: [('{env:SOURCE_DIR}/_temp/plugins', '{env:SOURCE_DIR}/examples/07-python-operators/plugins'), \
+    clean: ('{env:SOURCE_DIR}/_temp/04_advanced', '{env:SOURCE_DIR}/examples/04-advanced/02-volume_averaged_stress'), \
+    clean: ('{env:SOURCE_DIR}/_temp/12_fluids', '{env:SOURCE_DIR}/examples/12-fluids/02-fluids_results')]]; \
+    clean: [shutil.rmtree(p) for p in ['{env:SOURCE_DIR}/_temp'] if exists(p)]"
 
     # Build documentation
     html,links: {env_bin_dir}/sphinx-build -b {env:BUILDER} {env:SOURCE_DIR} {env:BUILD_DIR}/{env:BUILDER} {env:BUILDER_OPTS}
@@ -258,4 +258,4 @@ commands =
 commands_post =
     # Clear any running servers that may be locking resources
     html,links: python -c "import psutil; proc_name = 'Ans.Dpf.Grpc'; nb_procs = len([proc.kill() for proc in psutil.process_iter() if proc_name in proc.name()]); \
-                print(f'Killed \{nb_procs} \{proc_name} processes.')"
+    html,links: print(f'Killed \{nb_procs} \{proc_name} processes.')"


### PR DESCRIPTION
Reverts ansys/pydpf-core#2996.

Reason: tox `v4.43.0` and `v4.44.0` released shortly afterwards and sort of broke things again.