### PR TITLE
feat: expose `find_ansys` under `ansys.dpf.core`

### DIFF
--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -34,6 +34,7 @@ if any([c in installed for c in check_for]):
                       f"dependencies to run correctly.")
 
 from ansys.dpf.core.dpf_operator import Operator, Config
+from ansys.dpf.core.misc import find_ansys
 from ansys.dpf.core.model import Model
 from ansys.dpf.core.field import Field, FieldDefinition
 from ansys.dpf.core.custom_type_field import CustomTypeField  # noqa: F401


### PR DESCRIPTION
This pull request introduces a minor update to the `src/ansys/dpf/core/__init__.py` file. The main change is the addition of an import statement for the `find_ansys` function from the `ansys.dpf.core.misc` module, making this utility available at the package level.