### PR TITLE
feat: support new DPF ansys-style versioning

### DIFF
--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -31,7 +31,7 @@ min_server_version = "5.0"
 class ServerToAnsysVersion:
     def __getitem__(self, item):
         version = parse_version(item)
-        if version > 2025:
+        if version.major > 2025:
             # The new DPF versioning scheme is YEAR.REVISION.MICRO.MODIFIER
             ansys_year = version.major
             ansys_revision = version.minor

--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -31,12 +31,17 @@ min_server_version = "5.0"
 class ServerToAnsysVersion:
     def __getitem__(self, item):
         version = parse_version(item)
-        # The current DPF versioning scheme is MAJOR.MINOR.PATCH
-        # Compute release version equivalent (YEAR+'R'+REVISION)
-        # The revision is 'R1' for any odd major DPF version, 'R2' for even major versions.
-        ansys_revision = 2 - version.major % 2
-        # The year is 2021 for DPF 1.0, and bumped every two releases.
-        ansys_year = 2020 + version.major // 2 + version.major % 2
+        if version > 2025:
+            # The new DPF versioning scheme is YEAR.REVISION.MICRO.MODIFIER
+            ansys_year = version.major
+            ansys_revision = version.minor
+        else:
+            # The legacy DPF versioning scheme is MAJOR.MINOR.PATCH
+            # Compute release version equivalent (YEAR+'R'+REVISION)
+            # The revision is 'R1' for any odd major DPF version, 'R2' for even major versions.
+            ansys_revision = 2 - version.major % 2
+            # The year is 2021 for DPF 1.0, and bumped every two releases.
+            ansys_year = 2020 + version.major // 2 + version.major % 2
         # Return the corresponding Ansys release
         return f"{ansys_year}R{ansys_revision}"
 


### PR DESCRIPTION
This pull request updates the version parsing logic in the `ServerToAnsysVersion` class to support a new DPF versioning scheme. The main change is the addition of logic to handle versions beyond 2025, which now follow a different format.

Version parsing improvements:

* Updated the `__getitem__` method in `ServerToAnsysVersion` to distinguish between the legacy MAJOR.MINOR.PATCH scheme and the new YEAR.REVISION.MICRO.MODIFIER scheme for DPF versions greater than 2025.