### PR TITLE
docs(field): warn that scoping setter is metadata-only and coordinates_field is a live reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ src/ansys/dpf/core/examples/python_plugins/gltf_plugin/requirements.txt
 src/ansys/dpf/core/examples/python_plugins/gltf_plugin/texture.png
 src/ansys/dpf/core/examples/python_plugins/easy_statistics.py
 src/ansys/dpf/core/examples/python_plugins/gltf_plugin.xml
+
+# Git worktrees
+.worktrees/

--- a/src/ansys/dpf/core/field_base.py
+++ b/src/ansys/dpf/core/field_base.py
@@ -300,6 +300,19 @@ class _FieldBase:
 
     @scoping.setter
     def scoping(self, scoping):
+        """Set the scoping of the field.
+
+        .. warning::
+            This is a **metadata-only** operation. Setting the scoping replaces
+            the annotation that maps data entries to entity IDs; it does **not**
+            filter, resize, or reorder the underlying data buffer.
+            After the assignment, :attr:`elementary_data_count` still reflects
+            the original buffer size.
+
+            To obtain a field restricted to a subset of entities, use the
+            ``rescope`` operator, or call :meth:`deep_copy` and then reassign
+            the scoping on the copy.
+        """
         return self._set_scoping(scoping)
 
     @abstractmethod

--- a/src/ansys/dpf/core/nodes.py
+++ b/src/ansys/dpf/core/nodes.py
@@ -242,6 +242,18 @@ class Nodes:
         coordinates_field:
             Field with all the coordinates for the nodes.
 
+        .. warning::
+            This property returns a **live reference** to the mesh's internal
+            field object, not an independent copy. Mutating the returned
+            field's scoping or data modifies the mesh's internal state;
+            subsequent accesses to this property will reflect those mutations.
+
+            To work with an isolated copy, call :meth:`ansys.dpf.core.Field.deep_copy`
+            on the returned field before modifying it::
+
+                coords = nodes.coordinates_field.deep_copy()
+                # coords is now independent - safe to modify
+
         Examples
         --------
         >>> import ansys.dpf.core as dpf


### PR DESCRIPTION
## Summary

Documents two subtle behaviors in the PyDPF-Core field and mesh APIs:

1. **Scoping setter is metadata-only** - assigning a new scoping to a `Field` updates the index only; it does not filter or resize the underlying data array. The `rescope` operator or `deep_copy()` should be used instead.
2. **`nodes.coordinates_field` is a live reference** - the property returns a direct reference to the internal mesh coordinate array. Modifying it mutates the mesh in place. Use `deep_copy()` to obtain an independent copy.

## Changes

- `src/ansys/dpf/core/field_base.py`: added `.. warning::` docstring to `scoping.setter` recommending the `rescope` operator or `deep_copy()`
- `src/ansys/dpf/core/nodes.py`: added `.. warning::` docstring to `coordinates_field` getter recommending `deep_copy()`
- `.gitignore`: added `.worktrees/` entry

Relates to TFS US 1459270.