### PR TITLE
fix: labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,18 +1,26 @@
 documentation:
-- doc/source/**/*
-- examples/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - doc/source/**/*
+      - examples/**/*
 maintenance:
-- .flake8
-- CODE_OF_CONDUCT.md
-- LICENSE
-- README.md
-- codecov.yml
-- ignore_words.txt
-- setup.py
+  - changed-files:
+    - any-glob-to-any-file:
+      - .flake8
+      - CODE_OF_CONDUCT.md
+      - LICENSE
+      - README.md
+      - codecov.yml
+      - ignore_words.txt
+      - setup.py
 dependencies:
-- setup.py
-- requirements/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - setup.py
+      - requirements/*
 CI/CD:
-- docker/**/*
-- .github/**/*
-- .ci/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - docker/**/*
+      - .github/**/*
+      - .ci/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,17 @@ documentation:
   - changed-files:
     - any-glob-to-any-file:
       - doc/source/**/*
-      - examples/**/*
+      - doc/sphinx_utilities/**/*
+      - doc/styles/**/*
+      - doc/*
+examples:
+  - changed-files:
+    - any-glob-to-any-file:  
+      - doc/sphinx_gallery_examples/**/*
+tutorials:
+  - changed-files:
+    - any-glob-to-any-file:  
+      - doc/sphinx_gallery_tutorials/**/*
 maintenance:
   - changed-files:
     - any-glob-to-any-file:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request:
-    types: [unlabeled]
+    types: [opened, reopened, synchronize, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -87,5 +87,7 @@ jobs:
           - [enhancement](https://github.com/ansys/pydpf-core/pulls?q=label%3Aenhancement+)
           - [documentation](https://github.com/ansys/pydpf-core/pulls?q=label%3Adocumentation+)
           - [examples](https://github.com/ansys/pydpf-core/pulls?q=label%3Aexamples+)
+          - [tutorials](https://github.com/ansys/pydpf-core/pulls?q=label%3Atutorials+)
           - [maintenance](https://github.com/ansys/pydpf-core/pulls?q=label%3Amaintenance+)
+          - [dependencies](https://github.com/ansys/pydpf-core/pulls?q=label%3Adependencies+)
           - [CI/CD](https://github.com/ansys/pydpf-core/pulls?q=label%3Aci%2Fcd+)

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        sync-labels: ''
+        sync-labels: false
 
     # Label based on branch name
     - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.0.0


### PR DESCRIPTION
This fixes workflow failure such as [this](https://github.com/ansys/pydpf-core/actions/runs/26228827356/job/77183181358) and makes some additional changes:
- The `sync-label` input is a boolean, which is why the empty string is causing failure. I guess before now, validation of input values was not strict and the empty string was being treated as falsy.
- The action was only being triggered when a PR is unlabeled, which explains why the action has not really been running. @PProfizi, the action ran on [this PR](https://github.com/ansys/pydpf-core/pull/3214) because you unlabeled:
<img width="2095" height="180" alt="image" src="https://github.com/user-attachments/assets/a8bca700-0698-4898-8cf8-b6c7a88bfd6c" />

- `.github/labeler.yml` is outdated (causing [this failure](https://github.com/ansys/pydpf-core/actions/runs/26440334084/job/77832907689?pr=3224)) and has also been updated. 