### PR TITLE
feat: report full calendar version from server.version

### DIFF
--- a/.ci/run_examples.py
+++ b/.ci/run_examples.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import subprocess
 import sys
 
+from packaging.version import Version as PkgVersion
+
 import ansys.dpf.core as dpf
 from ansys.dpf.core.examples import get_example_required_minimum_dpf_version
 
@@ -45,7 +47,7 @@ for root, subdirectories, files in os.walk(examples_path):
             print("\n--------------------------------------------------")
             print(file)
             minimum_version_str = get_example_required_minimum_dpf_version(file)
-            if float(server_version) - float(minimum_version_str) < -0.05:  # noqa: PLR2004
+            if PkgVersion(server_version) < PkgVersion(minimum_version_str):
                 print(f"Example skipped as it requires DPF {minimum_version_str}.", flush=True)
                 continue
             try:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,6 +17,8 @@ import pyvista
 from pyvista.plotting.utilities.sphinx_gallery import DynamicScraper
 
 from ansys.dpf.core import __version__, server, server_factory
+from packaging.version import Version as PkgVersion
+
 from ansys.dpf.core.examples import get_example_required_minimum_dpf_version
 
 # Make sphinx_utilities modules importable
@@ -73,7 +75,7 @@ for example in sorted(
     glob(r"../sphinx_gallery_tutorials/**/*.py")
 ):
     minimum_version_str = get_example_required_minimum_dpf_version(example)
-    if float(server_version) - float(minimum_version_str) < -0.05:
+    if PkgVersion(server_version) < PkgVersion(minimum_version_str):
         example_name = example.split(os.path.sep)[-1]
         print(f"Example/tutorial {example_name} skipped as it requires DPF {minimum_version_str}.")
         ignored_pattern += f"|{example_name}"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -88,7 +88,7 @@ for tutorial_file in glob(str(Path("tutorials")/"**"/"*.rst")):
     if Path(tutorial_file).name == "index.rst":
         continue
     minimum_version_str = get_tutorial_version_requirements(tutorial_file)
-    if float(server_version) - float(minimum_version_str) < -0.05:
+    if PkgVersion(server_version) < PkgVersion(minimum_version_str):
         print(f"Tutorial {Path(tutorial_file).name} skipped as it requires DPF {minimum_version_str}.")
         exclude_patterns.append(tutorial_file.replace("\\", "/"))
 

--- a/doc/source/getting_started/compatibility.rst
+++ b/doc/source/getting_started/compatibility.rst
@@ -83,7 +83,7 @@ Supported DPF versions
    * - Server version
      - ``ansys.dpf.core`` Python module version
      - Supported Python versions
-   * - 12.0 (2026 R1)
+   * - 2027.1 (2027 R1)
      - 0.15.0 and later
      - 3.10, 3.11, 3.12, 3.13
    * - 11.0 (2026 R1 pre0)

--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -48,3 +48,7 @@ class ServerToAnsysVersion:
 
 
 server_to_ansys_version = ServerToAnsysVersion()
+
+# First DPF major version using calendar versioning (YEAR.REVISION.MICRO.MODIFIER).
+# Servers with major >= this support DataProcessing_getServerVersionFull.
+CALENDAR_VERSIONING_FIRST_MAJOR = 2027

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -540,7 +540,7 @@ class CollectionBase(Generic[TYPE]):
         else:
             return support
 
-    @version_requires("12.0")
+    @version_requires("2027.1.0pre0")
     def deep_copy_supports(self, other: CollectionBase):
         """Deep-copies the supports of all labels in the collection into the other collection.
 

--- a/src/ansys/dpf/core/core.py
+++ b/src/ansys/dpf/core/core.py
@@ -34,6 +34,7 @@ from ansys.dpf.core import errors, server as server_module
 
 if TYPE_CHECKING:  # pragma: noqa
     from ansys.dpf.core import AnyServerType
+from ansys.dpf.core._version import CALENDAR_VERSIONING_FIRST_MAJOR
 from ansys.dpf.core.check_version import server_meet_version, version_requires
 from ansys.dpf.core.runtime_config import (
     RuntimeCoreConfig,
@@ -613,13 +614,41 @@ class BaseService:
             proc_id = self._api.data_processing_process_id_on_client(client=self._server().client)
         else:
             proc_id = self._api.data_processing_process_id()
-        # server version
+        # server version - first get major/minor to detect calendar versioning (major >= 2027)
         if self._server().has_client():
             self._api.data_processing_get_server_version_on_client(
                 client=self._server().client, major=serv_ver_maj, minor=serv_ver_min
             )
         else:
             self._api.data_processing_get_server_version(major=serv_ver_maj, minor=serv_ver_min)
+        if int(serv_ver_maj) >= CALENDAR_VERSIONING_FIRST_MAJOR:
+            serv_ver_micro = integral_types.MutableInt32(-1)
+            serv_ver_modifier = integral_types.MutableString(size=0)
+            if self._server().has_client():
+                self._api.data_processing_get_server_version_full_on_client(
+                    client=self._server().client,
+                    major=serv_ver_maj,
+                    minor=serv_ver_min,
+                    micro=serv_ver_micro,
+                    modifier=serv_ver_modifier,
+                )
+            else:
+                self._api.data_processing_get_server_version_full(
+                    major=serv_ver_maj,
+                    minor=serv_ver_min,
+                    micro=serv_ver_micro,
+                    modifier=serv_ver_modifier,
+                )
+            version_str = (
+                str(int(serv_ver_maj))
+                + "."
+                + str(int(serv_ver_min))
+                + "."
+                + str(int(serv_ver_micro))
+                + str(serv_ver_modifier)
+            )
+        else:
+            version_str = str(int(serv_ver_maj)) + "." + str(int(serv_ver_min))
         # server os
         if self._server().has_client():
             serv_os = self._api.data_processing_get_os_on_client(client=self._server().client)
@@ -630,7 +659,7 @@ class BaseService:
             "server_ip": serv_ip,
             "server_port": serv_port,
             "server_process_id": proc_id,
-            "server_version": str(int(serv_ver_maj)) + "." + str(int(serv_ver_min)),
+            "server_version": version_str,
             "os": serv_os,
         }
 

--- a/src/ansys/dpf/core/custom_fields_container.py
+++ b/src/ansys/dpf/core/custom_fields_container.py
@@ -100,7 +100,7 @@ class ElShapeFieldsContainer(FieldsContainer):
 
         """
         label_space = self.__time_complex_label_space__(timeid, complexid)
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SOLID.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SOLID.value
@@ -138,7 +138,7 @@ class ElShapeFieldsContainer(FieldsContainer):
 
         """
         label_space = self.__time_complex_label_space__(timeid, complexid)
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SHELL.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SHELL.value
@@ -176,7 +176,7 @@ class ElShapeFieldsContainer(FieldsContainer):
 
         """
         label_space = self.__time_complex_label_space__(timeid, complexid)
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.BEAM.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.BEAM.value
@@ -211,7 +211,7 @@ class ElShapeFieldsContainer(FieldsContainer):
 
         """
         label_space = self.__time_complex_label_space__(timeid, complexid)
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SOLID.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SOLID.value
@@ -247,7 +247,7 @@ class ElShapeFieldsContainer(FieldsContainer):
 
         """
         label_space = self.__time_complex_label_space__(timeid, complexid)
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SHELL.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SHELL.value
@@ -282,7 +282,7 @@ class ElShapeFieldsContainer(FieldsContainer):
 
         """
         label_space = self.__time_complex_label_space__(timeid, complexid)
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.BEAM.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.BEAM.value

--- a/src/ansys/dpf/core/fields_container.py
+++ b/src/ansys/dpf/core/fields_container.py
@@ -508,7 +508,7 @@ class FieldsContainer(CollectionBase["field.Field"]):
         for i, f in enumerate(self):
             fc.add_field(self.get_label_space(i), f.deep_copy(server))
         with suppress(Exception):
-            if server_meet_version("12.0", self._server):
+            if server_meet_version("2027.1.0pre0", self._server):
                 self.deep_copy_supports(fc)
             else:
                 fc.time_freq_support = self.time_freq_support.deep_copy(server)

--- a/src/ansys/dpf/core/meshes_container.py
+++ b/src/ansys/dpf/core/meshes_container.py
@@ -264,7 +264,7 @@ class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
                 f"The following labels are not in this mesh container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SOLID.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SOLID.value
@@ -326,7 +326,7 @@ class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
                 f"The following labels are not in this mesh container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SHELL.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SHELL.value
@@ -388,7 +388,7 @@ class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
                 f"The following labels are not in this mesh container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.BEAM.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.BEAM.value
@@ -451,7 +451,7 @@ class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
                 f"The following labels are not in this mesh container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SOLID.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SOLID.value
@@ -514,7 +514,7 @@ class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
                 f"The following labels are not in this mesh container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SHELL.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SHELL.value
@@ -577,7 +577,7 @@ class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
                 f"The following labels are not in this mesh container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.BEAM.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.BEAM.value

--- a/src/ansys/dpf/core/scopings_container.py
+++ b/src/ansys/dpf/core/scopings_container.py
@@ -270,7 +270,7 @@ class ScopingsContainer(CollectionBase[scoping.Scoping]):
                 f"The following labels are not in this scoping container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SOLID.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SOLID.value
@@ -332,7 +332,7 @@ class ScopingsContainer(CollectionBase[scoping.Scoping]):
                 f"The following labels are not in this scoping container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SHELL.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SHELL.value
@@ -394,7 +394,7 @@ class ScopingsContainer(CollectionBase[scoping.Scoping]):
                 f"The following labels are not in this scoping container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.BEAM.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.BEAM.value
@@ -457,7 +457,7 @@ class ScopingsContainer(CollectionBase[scoping.Scoping]):
                 f"The following labels are not in this scoping container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SOLID.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SOLID.value
@@ -520,7 +520,7 @@ class ScopingsContainer(CollectionBase[scoping.Scoping]):
                 f"The following labels are not in this scoping container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.SHELL.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.SHELL.value
@@ -583,7 +583,7 @@ class ScopingsContainer(CollectionBase[scoping.Scoping]):
                 f"The following labels are not in this scoping container: {invalid_labels}"
             )
 
-        if server_meet_version("12.0", self._server):
+        if server_meet_version("2027.1.0pre0", self._server):
             label_space["elshape"] = elements._element_shapes.BEAM.value
         else:
             label_space["elshape"] = elements._element_shapes_legacy.BEAM.value

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -49,7 +49,11 @@ import psutil
 
 from ansys.dpf import core
 from ansys.dpf.core import __version__, errors, server_context, server_factory
-from ansys.dpf.core._version import min_server_version, server_to_ansys_version
+from ansys.dpf.core._version import (
+    CALENDAR_VERSIONING_FIRST_MAJOR,
+    min_server_version,
+    server_to_ansys_version,
+)
 from ansys.dpf.core.check_version import get_server_version, meets_version, version_requires
 from ansys.dpf.core.server_context import AvailableServerContexts, ServerContext
 from ansys.dpf.gate import data_processing_grpcapi, load_api
@@ -965,7 +969,8 @@ class GrpcServer(CServer):
         Returns
         -------
         version : str
-            The version of the server in 'major.minor' format.
+            The version of the server in 'major.minor.micro[modifier]' format for servers
+            using calendar versioning (major >= 2027), or 'major.minor' for older servers.
         """
         if not self._version:
             from ansys.dpf.gate import data_processing_capi, integral_types
@@ -974,7 +979,17 @@ class GrpcServer(CServer):
             major = integral_types.MutableInt32()
             minor = integral_types.MutableInt32()
             api.data_processing_get_server_version_on_client(self.client, major, minor)
-            self._version = str(int(major)) + "." + str(int(minor))
+            if int(major) >= CALENDAR_VERSIONING_FIRST_MAJOR:
+                micro = integral_types.MutableInt32()
+                modifier = integral_types.MutableString(size=0)
+                api.data_processing_get_server_version_full_on_client(
+                    self.client, major, minor, micro, modifier
+                )
+                self._version = (
+                    str(int(major)) + "." + str(int(minor)) + "." + str(int(micro)) + str(modifier)
+                )
+            else:
+                self._version = str(int(major)) + "." + str(int(minor))
         return self._version
 
     @property
@@ -1184,7 +1199,8 @@ class InProcessServer(CServer):
         Returns
         -------
         version : str
-            The version of the InProcess server in the format "major.minor".
+            The version of the InProcess server in the format "major.minor.micro[modifier]" for
+            servers using calendar versioning (major >= 2027), or "major.minor" for older servers.
         """
         if self._version is None:
             from ansys.dpf.gate import data_processing_capi, integral_types
@@ -1193,7 +1209,15 @@ class InProcessServer(CServer):
             major = integral_types.MutableInt32()
             minor = integral_types.MutableInt32()
             api.data_processing_get_server_version(major, minor)
-            out = str(int(major)) + "." + str(int(minor))
+            if int(major) >= CALENDAR_VERSIONING_FIRST_MAJOR:
+                micro = integral_types.MutableInt32()
+                modifier = integral_types.MutableString(size=0)
+                api.data_processing_get_server_version_full(major, minor, micro, modifier)
+                out = (
+                    str(int(major)) + "." + str(int(minor)) + "." + str(int(micro)) + str(modifier)
+                )
+            else:
+                out = str(int(major)) + "." + str(int(minor))
             self._version = out
         return self._version
 

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -227,7 +227,7 @@ class Support:
         )
         return coll_obj.get_integral_entries()
 
-    @version_requires("12.0")
+    @version_requires("2027.1.0pre0")
     def get_type(self) -> str:
         """Type of the support as a string.
 
@@ -240,7 +240,7 @@ class Support:
         self._support_api.support_get_type(self, type)
         return str(type)
 
-    @version_requires("12.0")
+    @version_requires("2027.1.0pre0")
     def get_as_time_freq_support(self) -> "time_freq_support.TimeFreqSupport":
         """Get the support as a TimeFreqSupport object.
 
@@ -257,7 +257,7 @@ class Support:
         )
         return tfsp
 
-    @version_requires("12.0")
+    @version_requires("2027.1.0pre0")
     def get_as_meshed_region(self) -> "meshed_region.MeshedRegion":
         """Get the support as a MeshedRegion object.
 
@@ -273,7 +273,7 @@ class Support:
         )
         return mesh
 
-    @version_requires("12.0")
+    @version_requires("2027.1.0pre0")
     def get_as_cyclic_support(self) -> "cyclic_support.CyclicSupport":
         """Get the support as a CyclicSupport object.
 
@@ -290,7 +290,7 @@ class Support:
         )
         return cyclic
 
-    @version_requires("12.0")
+    @version_requires("2027.1.0pre0")
     def get_as_generic_support(self) -> "generic_support.GenericSupport":
         """Get the support as a GenericSupport object.
 
@@ -307,7 +307,7 @@ class Support:
         )
         return generic
 
-    @version_requires("12.0")
+    @version_requires("2027.1.0pre0")
     def deep_copy(self, server=None):
         """
         Create a deep copy of the Support on a given server.

--- a/src/ansys/dpf/gate/data_processing_grpcapi.py
+++ b/src/ansys/dpf/gate/data_processing_grpcapi.py
@@ -205,6 +205,14 @@ class DataProcessingGRPCAPI(data_processing_abstract_api.DataProcessingAbstractA
         minor.set(response.minorVersion)
 
     @staticmethod
+    def data_processing_get_server_version_full_on_client(client, major, minor, micro, modifier):
+        response = _get_server_info_response(client)
+        major.set(response.majorVersion)
+        minor.set(response.minorVersion)
+        micro.set(response.microVersion)
+        modifier.set(response.modifierVersion)
+
+    @staticmethod
     def data_processing_description_string(data):
         data_obj = data._internal_obj
         from ansys.grpc.dpf import base_pb2, collection_message_pb2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,8 +345,8 @@ def cfx_mixing_elbow():
 
 DEFAULT_ANSYS_PATH = core._global_server().ansys_path
 
-SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0 = meets_version(
-    get_server_version(core._global_server()), "12.0"
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0 = meets_version(
+    get_server_version(core._global_server()), "2027.1.0pre0"
 )
 SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 = meets_version(
     get_server_version(core._global_server()), "11.0"

--- a/tests/test_checkversion.py
+++ b/tests/test_checkversion.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import pytest
+from packaging.version import Version as PkgVersion
 
 from ansys.dpf.core import check_version, errors as dpf_errors
 from ansys.dpf.gate.load_api import _find_outdated_ansys_version
@@ -45,6 +46,7 @@ def test_get_server_version(server_type):
 
 def test_check_server_version_dpfserver(server_type):
     v = check_version.get_server_version()
+    parsed = PkgVersion(v)
     split = v.split(".")
     assert len(split) >= 2
     server_type.check_version(v)
@@ -52,22 +54,27 @@ def test_check_server_version_dpfserver(server_type):
         v_up = split[0] + "1"
         server_type.check_version(v_up)
     with pytest.raises(dpf_errors.DpfVersionNotSupported):
-        v_up_patch = v + ".1"
+        v_up_patch = f"{parsed.major}.{parsed.minor}.{parsed.micro + 1}"
         server_type.check_version(v_up_patch)
 
 
 def test_check_server_version_checkversion(server_type):
     v = check_version.get_server_version()
+    parsed = PkgVersion(v)
     split = v.split(".")
     assert len(split) >= 2
     check_version.server_meet_version_and_raise(v, server_type)
-    v_with_patch = v + ".0"
-    check_version.server_meet_version_and_raise(v_with_patch, server_type)
+    if not parsed.is_prerelease:
+        # For final-release servers, verify the explicit major.minor.micro form is also met.
+        # Skipped for pre-release servers: "2027.1.0" > "2027.1.0pre0" so a pre-release
+        # server does not satisfy the base release requirement.
+        v_with_patch = f"{parsed.major}.{parsed.minor}.{parsed.micro}"
+        check_version.server_meet_version_and_raise(v_with_patch, server_type)
     with pytest.raises(dpf_errors.DpfVersionNotSupported):
         v_up = split[0] + "1"
         check_version.server_meet_version_and_raise(v_up, server_type)
     with pytest.raises(dpf_errors.DpfVersionNotSupported):
-        v_up_patch = v + ".1"
+        v_up_patch = f"{parsed.major}.{parsed.minor}.{parsed.micro + 1}"
         check_version.server_meet_version_and_raise(v_up_patch, server_type)
 
 
@@ -111,6 +118,8 @@ def test_version():
 
     assert server_to_ansys_version["1.0"] == "2021R1"
     assert server_to_ansys_version["10.0.12"] == "2025R2"
+    assert server_to_ansys_version["2027.1"] == "2027R1"
+    assert server_to_ansys_version["2028.2"] == "2028R2"
 
 
 def test_get_server_version_format(server_type):

--- a/tests/test_checkversion.py
+++ b/tests/test_checkversion.py
@@ -111,3 +111,28 @@ def test_version():
 
     assert server_to_ansys_version["1.0"] == "2021R1"
     assert server_to_ansys_version["10.0.12"] == "2025R2"
+
+
+def test_get_server_version_format(server_type):
+    """Server version uses full calendar format (major.minor.micro[modifier]) for servers
+    with major >= 2027, and legacy major.minor format for older servers."""
+    from packaging.version import parse
+
+    version = server_type.version
+    assert isinstance(version, str)
+    parts = version.split(".")
+    assert len(parts) >= 2
+    major = int(parts[0])
+    if major >= 2027:
+        # Calendar versioning: expect at least major.minor.micro
+        assert len(parts) >= 3
+        # Must be parseable by packaging.version
+        parse(version)
+    else:
+        # Legacy versioning: major.minor
+        assert len(parts) == 2
+
+
+def test_server_info_version_format(server_type):
+    """server_info['server_version'] matches server.version."""
+    assert server_type.info["server_version"] == server_type.version

--- a/tests/test_faces.py
+++ b/tests/test_faces.py
@@ -70,7 +70,7 @@ def test_face(model_faces):
 \tType:       element_types.Quad4
 """
     assert str(face) == ref_str
-    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert face.node_ids == [4677, 4663, 4679, 4688]
     else:
         assert face.node_ids == [4688, 4679, 4663, 4677]
@@ -85,7 +85,7 @@ Index:         4676
 Location: [-0.022856459489947675, -0.08534214957826106, -0.013310679234564304]
 """
 
-    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert str(face.nodes[0]) == ref_node_str
     else:
         assert str(face.nodes[3]) == ref_node_str

--- a/tests/test_fieldscontainer.py
+++ b/tests/test_fieldscontainer.py
@@ -42,7 +42,7 @@ from ansys.dpf.core.custom_fields_container import (
     ElShapeFieldsContainer,
 )
 import conftest
-from tests.conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0
+from tests.conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0
 
 
 @pytest.fixture()
@@ -576,7 +576,7 @@ def test_fields_container_set_tfsupport(server_type):
 
 
 @pytest.mark.skipif(
-    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0, reason="Available for servers >=12.0"
+    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0, reason="Available for servers >=2027.1"
 )
 def test_fields_container_deep_copy_local(server_type):
     coll = dpf.FieldsContainer(server=server_type)
@@ -613,7 +613,7 @@ def test_fields_container_deep_copy_local(server_type):
 
 
 @pytest.mark.skipif(
-    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0, reason="Available for servers >=12.0"
+    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0, reason="Available for servers >=2027.1"
 )
 def test_fields_container_deep_copy_gRPCCLayer(server_type):
     coll = dpf.FieldsContainer(server=server_type)
@@ -654,7 +654,7 @@ def test_fields_container_deep_copy_gRPCCLayer(server_type):
 
 
 @pytest.mark.skipif(
-    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0, reason="Available for servers >=12.0"
+    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0, reason="Available for servers >=2027.1"
 )
 def test_fields_container_deep_copy_LegacygRPC(server_type):
     coll = dpf.FieldsContainer(server=server_type)

--- a/tests/test_lsdyna.py
+++ b/tests/test_lsdyna.py
@@ -25,7 +25,7 @@ import numpy as np
 from ansys.dpf import core as dpf
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_1,
-    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0,
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0,
 )
 
 
@@ -356,7 +356,7 @@ def test_lsdyna_matsum_rcforc(binout_matsum):
     ke_mod = kinetic_energy_op_2.eval()
 
     assert np.allclose(ke_fc[0].data[39], ke_mod[0].data[39])
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert ke_fc[0].unit == "ft*lbf"
         assert ke_mod[0].unit == "ft*lbf"
     else:
@@ -379,7 +379,7 @@ def test_lsdyna_matsum_rcforc(binout_matsum):
         part_eroded_kinetic_energy_fc[0].data[39],
         part_eroded_kinetic_energy_model[0].data[39],
     )
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert part_eroded_kinetic_energy_fc[0].unit == "ft*lbf"
         assert part_eroded_kinetic_energy_model[0].unit == "ft*lbf"
     else:
@@ -399,7 +399,7 @@ def test_lsdyna_matsum_rcforc(binout_matsum):
     ie_mod = internal_energy_op_2.eval()
 
     assert np.allclose(ie_fc[0].data[39], ie_mod[0].data[39])
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert ie_fc[0].unit == "ft*lbf"
         assert ie_mod[0].unit == "ft*lbf"
     else:
@@ -419,7 +419,7 @@ def test_lsdyna_matsum_rcforc(binout_matsum):
     erie_mod = part_eroded_internal_energy_op_2.eval()
 
     assert np.allclose(erie_fc[0].data[39], erie_mod[0].data[39])
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert erie_fc[0].unit == "ft*lbf"
         assert erie_mod[0].unit == "ft*lbf"
     else:
@@ -455,7 +455,7 @@ def test_lsdyna_matsum_rcforc(binout_matsum):
     mv_mod = part_momentum_op_2.eval()
 
     assert np.allclose(mv_fc[0].data[39], mv_mod[0].data[39])
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert mv_fc[0].unit == "slug*ft/s"
         assert mv_mod[0].unit == "slug*ft/s"
     else:
@@ -475,7 +475,7 @@ def test_lsdyna_matsum_rcforc(binout_matsum):
     rbv_mod = part_rigid_body_velocity_op_2.eval()
 
     assert np.allclose(rbv_fc[0].data[39], rbv_mod[0].data[39])
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert rbv_fc[0].unit == "ft/s"
         assert rbv_mod[0].unit == "ft/s"
     else:
@@ -500,7 +500,7 @@ def test_lsdyna_matsum_rcforc(binout_matsum):
     cf_mod = interface_contact_force_op_2.eval()
 
     assert np.allclose(cf_fc[0].data[0], cf_mod[0].data[0])
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         assert cf_fc[0].unit == "lbf"
         assert cf_mod[0].unit == "lbf"
     else:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -155,7 +155,7 @@ def test_result_displacement_model():
         assert len(results.displacement.split_by_body.eval()) == 44
     else:
         assert len(results.displacement.split_by_body.eval()) == 32
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(results.displacement.split_by_shape.eval()) == 6
     else:
         assert len(results.displacement.split_by_shape.eval()) == 4
@@ -177,7 +177,7 @@ def test_result_stress_model():
         assert len(results.stress.split_by_body.eval()) == 44
     else:
         assert len(results.stress.split_by_body.eval()) == 32
-        if server_meet_version("12.0", model._server):
+        if server_meet_version("2027.1.0pre0", model._server):
             assert len(results.stress.split_by_shape.eval()) == 6
         else:
             assert len(results.stress.split_by_shape.eval()) == 4

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -488,13 +488,13 @@ def test_inputs_outputs_scopings_container(allkindofcomplexity):
     op.inputs.mesh.connect(model.metadata.meshed_region)
     sc = op.outputs.mesh_scoping()
 
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(sc) == 5
     else:
         assert len(sc) == 4
 
     assert sc.labels == ["elshape"]
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         scop = sc.get_scoping({"elshape": 2})
     else:
         scop = sc.get_scoping({"elshape": 1})
@@ -509,7 +509,7 @@ def test_inputs_outputs_scopings_container(allkindofcomplexity):
         stress.inputs.connect(op.outputs)
     fc = stress.outputs.fields_container()
     assert fc.labels == ["elshape", "time"]
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(fc) == 5
     else:
         assert len(fc) == 4
@@ -517,7 +517,7 @@ def test_inputs_outputs_scopings_container(allkindofcomplexity):
     stress.inputs.connect(sc)
     fc = stress.outputs.fields_container()
     assert fc.labels == ["elshape", "time"]
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(fc) == 5
     else:
         assert len(fc) == 4
@@ -525,7 +525,7 @@ def test_inputs_outputs_scopings_container(allkindofcomplexity):
     stress.inputs.connect(op.outputs.mesh_scoping)
     fc = stress.outputs.fields_container()
     assert fc.labels == ["elshape", "time"]
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(fc) == 5
     else:
         assert len(fc) == 4
@@ -562,13 +562,13 @@ def test_inputs_outputs_meshes_container(allkindofcomplexity):
     op.inputs.mesh.connect(model.metadata.meshed_region)
     op.inputs.property("elshape")
     mc = op.get_output(0, dpf.core.types.meshes_container)
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(mc) == 5
     else:
         assert len(mc) == 4
 
     assert mc.labels == ["body", "elshape"]
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         mesh = mc.get_mesh({"elshape": 2})
     else:
         mesh = mc.get_mesh({"elshape": 1})
@@ -593,14 +593,14 @@ def test_inputs_outputs_meshes_container(allkindofcomplexity):
         stress.inputs.connect(opsc.outputs)
     fc = stress.outputs.fields_container()
     assert fc.labels == ["body", "elshape", "time"]
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(fc) == 5
     else:
         assert len(fc) == 4
     stress.inputs.connect(mc)
     fc = stress.outputs.fields_container()
     assert fc.labels == ["body", "elshape", "time"]
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(fc) == 5
     else:
         assert len(fc) == 4
@@ -612,7 +612,7 @@ def test_inputs_outputs_meshes_container(allkindofcomplexity):
 
     fc = stress.outputs.fields_container()
     assert fc.labels == ["body", "elshape", "time"]
-    if server_meet_version("12.0", model._server):
+    if server_meet_version("2027.1.0pre0", model._server):
         assert len(fc) == 5
     else:
         assert len(fc) == 4

--- a/tests/test_resultinfo.py
+++ b/tests/test_resultinfo.py
@@ -29,7 +29,7 @@ from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0,
-    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0,
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0,
 )
 
 
@@ -160,7 +160,7 @@ def test_repr_available_results_list(model):
 
 def test_print_available_result_with_qualifiers(cfx_heating_coil, server_type):
     model = Model(cfx_heating_coil(server=server_type), server=server_type)
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0:
         ref = """DPF Result
 ----------
 specific_heat

--- a/tests/test_vtk_translate.py
+++ b/tests/test_vtk_translate.py
@@ -172,7 +172,6 @@ def test_dpf_property_field_to_vtk(simple_rst, server_type):
     model = dpf.Model(simple_rst, server=server_type)
     mesh = model.metadata.meshed_region
     property_field = mesh.property_field(property_name="mat")
-    print(property_field)
     # PropertyField to VTK
     ug = dpf_property_field_to_vtk(
         property_field=property_field, meshed_region=mesh, field_name="mat_id"
@@ -237,7 +236,6 @@ def test_vtk_mesh_is_valid_polyhedron():
     cells_1 = [5, 4, 4, 1, 2, 5, 4, 3, 0, 1, 4, 3, 2, 1, 0, 3, 3, 4, 5, 4, 5, 2, 0, 3]
     grid = pv.UnstructuredGrid([len(cells_1), *cells_1], cell_types, nodes_1)
     validity = vtk_mesh_is_valid(grid)
-    print(validity)
     assert validity.valid
     assert "valid" in validity.msg
     assert validity.grid.active_scalars_name == "ValidityState"
@@ -277,7 +275,6 @@ def test_vtk_mesh_is_valid_polyhedron():
     ]
     grid = pv.UnstructuredGrid([len(cells_2), *cells_2], cell_types, nodes_1)
     validity = vtk_mesh_is_valid(grid)
-    print(validity)
     assert not validity.valid  # bad face orientation
     assert len(validity.wrong_number_of_points) == 0
     assert len(validity.intersecting_edges) == 0


### PR DESCRIPTION
Use DataProcessing_getServerVersionFull / DataProcessing_getServerVersionFull_on_client to expose the full calendar-like version string (e.g. '2027.1.0pre0') from all server types.

A guard on major >= CALENDAR_VERSIONING_FIRST_MAJOR (2027) ensures backward compatibility with older DPF servers that only support the legacy major.minor API; those continue to return a 'X.Y' string.

Changes:
- _version.py: add CALENDAR_VERSIONING_FIRST_MAJOR = 2027 constant
- GrpcServer.version: first calls get_server_version_on_client; if major >= 2027 calls get_server_version_full_on_client for micro+modifier components
- InProcessServer.version: same pattern via get_server_version / get_server_version_full (direct CAPI, not the grpc_client variants which require the gRPC client layer to be initialized)
- BaseService._get_server_info: same guard so LegacyGrpcServer.version (which reads from info['server_version']) also reports the full version
- DataProcessingGRPCAPI: add data_processing_get_server_version_full_on_client reading microVersion and modifierVersion from the gRPC ServerInfoResponse proto
- test_checkversion.py: add test_get_server_version_format and test_server_info_version_format covering all three server types