### PR TITLE
fix(custom operator): custom operator now report non connected pins values as None

### DIFF
--- a/src/ansys/dpf/core/custom_operator.py
+++ b/src/ansys/dpf/core/custom_operator.py
@@ -316,7 +316,10 @@ class CustomOperatorBase:
             if type is type_tuple[0]:
                 if len(type_tuple) >= 3:  # noqa: PLR2004
                     parameters = {type_tuple[2]: type_tuple[1](self._operator_data, index)}
-                    return type(**parameters)
+                    if parameters[type_tuple[2]] is not None:
+                        return type(**parameters)
+                    else:
+                        return None
                 return type(type_tuple[1](self._operator_data, index))
         if type == dpf_vector.DPFVectorInt:
             size = integral_types.MutableInt32(0)

--- a/src/ansys/dpf/core/examples/python_plugins/custom_operator_example.py
+++ b/src/ansys/dpf/core/examples/python_plugins/custom_operator_example.py
@@ -114,7 +114,9 @@ class CustomOperator(CustomOperatorBase):
         # # If function returns None, there is no Field connected to this input
         if field is None:
             # # Try requesting the input as a FieldsContainer
-            field: dpf.FieldsContainer = self.get_input(0, dpf.FieldsContainer).get_field(0)
+            fc = dpf.FieldsContainer = self.get_input(0, dpf.FieldsContainer)
+            if fc:
+                field: dpf.Field = fc.get_field(0)
         # # If the input is optional, set its default value
         # # If the input is not optional and empty, raise an error
         if field is None:

--- a/tests/test_python_plugins.py
+++ b/tests/test_python_plugins.py
@@ -38,6 +38,7 @@ from ansys.dpf.core.operator_specification import (
 )
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0,
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0
 )
 
 # if platform.python_version().startswith("3.7"):
@@ -415,3 +416,25 @@ def test_custom_op_changelog(server_type_remote_process, testfiles_dir):
     assert changelog.last_version == Version("1.0.0")
     assert changelog[Version("1.0.0")] == "Major bump"
     assert op.version == Version("1.0.0")
+
+
+@pytest.mark.skipif(
+    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0, reason="Available for servers >=2027.1.pre0"
+)
+def test_custom_op_input_not_connected(server_type_remote_process, testfiles_dir):
+    from packaging.version import Version
+
+    dpf.load_library(
+        dpf.path_utilities.to_server_os(
+            Path(testfiles_dir) / "pythonPlugins", server_type_remote_process
+        ),
+        "py_operator_with_spec",
+        "load_operators",
+        server=server_type_remote_process,
+    )
+    op = dpf.Operator("custom_add_to_field", server=server_type_remote_process)
+    with pytest.raises(DPFServerException) as e:
+        _ = op.outputs.field()
+        expected = "ValueError: custom_add_to_field: mandatory pin 'field' is not connected."
+        assert expected in str(e)
+

--- a/tests/testfiles/pythonPlugins/operator_with_spec.py
+++ b/tests/testfiles/pythonPlugins/operator_with_spec.py
@@ -32,6 +32,8 @@ from ansys.dpf.core.operator_specification import (
 class AddFloatToFieldData(CustomOperatorBase):
     def run(self):
         field = self.get_input(0, Field)
+        if field is None:
+            raise ValueError(f"{self.name}: mandatory pin '{self.specification.inputs[0].name}' is not connected.")
         to_add = self.get_input(1, float)
         data = field.data
         data += to_add


### PR DESCRIPTION
Fixes #1008 

Custom Python operators allow users to write operators using PyDPF-Core scripting.
The `CustomOperatorBase` class brings the necessary methods for these operators to correctly interact with the server once loaded.
Its `get_input` method though did return empty objects instead of None in the case the server reported nothing (None) to be connected to this particular input pin.
We now correctly return None to the run function of the custom operator.