### PR TITLE
fix: broken link in documentarian section

### DIFF
--- a/doc/source/contribute/developer.rst
+++ b/doc/source/contribute/developer.rst
@@ -1,6 +1,6 @@
-.. _contributing_as_a_developer:
-
 .. include:: ../links.rst
+
+.. _contributing_as_a_developer:
 
 Contributing as a developer
 ###########################


### PR DESCRIPTION
As the title states. Link broken [here](https://dpf.docs.pyansys.com/version/stable/contribute/documentarian.html#contributing-to-the-documentation):
<img width="1088" height="493" alt="image" src="https://github.com/user-attachments/assets/ab65338e-931d-4569-bd90-8cfcdf5a2689" />

The fix is to change the location of the include statement, it shouldn't come between a label and the target section title.