### PR TITLE
enhancement: Clarify key vs file format in operator documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,7 @@ apps for both data input and data output, including visualization and
 result plots. It can access data from solver result files and other neutral
 formats, such as CSV, HDF5, and VTK files.
 
-The latest version of DPF supports Ansys solver results files for:
-
-- Mechanical APDL (`.rst`, `.mode`, `.rfrq`, `.rdsp`, `.rth`)
-- LS-DYNA (`.d3plot`, `.binout`)
-- Fluent (`.cas/dat.h5`, `.flprj`)
-- CFX (`.cas/dat.cff`, `.flprj`, `.res`)
-
-For more information on file support, see the [main page](https://dpf.docs.pyansys.com/version/stable/index.html)
+For information on file support, see the [main page](https://dpf.docs.pyansys.com/version/stable/index.html)
 in the PyDPF-Core documentation.
 
 Using the many DPF operators that are available, you can manipulate and

--- a/src/ansys/dpf/core/documentation/operator_doc_template.j2
+++ b/src/ansys/dpf/core/documentation/operator_doc_template.j2
@@ -16,7 +16,7 @@ license: {{ scripting_info.license }}
 {% if is_router %}
 ## Supported file types
 
-This operator supports the following keys ([file formats](../../index.md#overview-of-dpf)) for each listed namespace (plugin/solver):
+This operator supports the following [result file types](../../index.md#overview-of-dpf) and associated file extensions:
 {% for namespace, supported_files in supported_file_types.items() | sort %}
 - {{ namespace }}: {{ supported_files | join(", ") }} {% endfor %}
 {% endif %}


### PR DESCRIPTION
Update the operator doc template to clarify the presentation of supported file formats to better fit with the Operator Search vocabulary.