### PR TITLE
chore: bump ansys/actions/check-vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PyAnsys Vulnerability check (on ${{ github.ref == 'refs/heads/main' && 'main' || 'dev mode' }})
-        uses: ansys/actions/check-vulnerabilities@84b6533ae76f5dde69a1df26c18682160a8121cf # v10.3.5
+        uses: ansys/actions/check-vulnerabilities@9dc4e3161033d2c2485fbf9687d40cfb7a661fb2 # v10.3.6
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: "ansys-dpf-core"


### PR DESCRIPTION
As the title states. `ansys/actions/check-vulnerabilities@v10.3.5` was failing (examples: [1](https://github.com/ansys/pydpf-core/actions/runs/30783394921/job/91592259360) and [2](https://github.com/ansys/pydpf-core/actions/runs/30747484160/job/91495427065)) and `v10.3.6` was released solely to address that.