### PR TITLE
chore: pin `trame-client` to fix doc-build errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ doc = [
   "sphinx-reredirects==0.1.6",
   "sphinx_design==0.7.0",
   "sphinxcontrib-napoleon==0.7",
-  "trame-client!=3.13.3",
+  "trame-client<3.13.3",
   "vtk==9.6.0"
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-dpf-core"
 version = "0.16.2.dev0"
 description = "Data Processing Framework - Python Core "
 readme = "README.md"
-requires-python = ">=3.11, <4"
+requires-python = ">=3.10, <4"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-dpf-core"
 version = "0.16.2.dev0"
 description = "Data Processing Framework - Python Core "
 readme = "README.md"
-requires-python = ">=3.10, <4"
+requires-python = ">=3.11, <4"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [
@@ -92,6 +92,7 @@ doc = [
   "sphinx-reredirects==0.1.6",
   "sphinx_design==0.7.0",
   "sphinxcontrib-napoleon==0.7",
+  "trame-client!=3.13.3",
   "vtk==9.6.0"
 ]
 test = [


### PR DESCRIPTION
`trame-client` `3.13.3` (a transitive doc dependency) released earlier today is breaking the documentation build. This should fix it.