### PR TITLE
feat(errors): add support for the new DPF structured server errors

### DIFF
--- a/src/ansys/dpf/core/errors.py
+++ b/src/ansys/dpf/core/errors.py
@@ -28,6 +28,7 @@ from ansys.dpf.gate.errors import (  # noqa: F401
     DPFServerException,
     DPFServerNullObject,
     DpfVersionNotSupported,
+    OperatorFrame,
 )  # noqa: F401
 
 _COMPLEX_PLOTTING_ERROR_MSG = """

--- a/src/ansys/dpf/gate/errors.py
+++ b/src/ansys/dpf/gate/errors.py
@@ -1,17 +1,62 @@
+import json
 import types
 import sys
+from collections import namedtuple
 from functools import wraps
 
+OperatorFrame = namedtuple("OperatorFrame", ["name", "id"])
+"""An operator that a structured DPF error passed through (name and id)."""
+
+
+def _parse_structured_error(msg):
+    """Return the parsed structured DPF error, or ``None`` when ``msg`` is not one.
+
+    A structured error is a JSON document holding a ``"frames"`` mapping, keyed by
+    string indices where ``"0"`` is the innermost root cause.
+    """
+    if not isinstance(msg, str):
+        return None
+    text = msg.strip()
+    if not text.startswith("{"):
+        return None
+    try:
+        data = json.loads(text)
+    except ValueError:
+        return None
+    if not isinstance(data, dict) or "frames" not in data:
+        return None
+    return data
+
+
 class DPFServerException(Exception):
-    """Error raised when the DPF server has encountered an error."""
+    """Error raised when the DPF server has encountered an error.
+
+    When the server reports a structured error, these attributes are populated
+    from the root cause and its nested chain:
+
+    - ``type``: stable error type of the root cause (``None`` if unknown).
+    - ``what``: root cause message.
+    - ``suggestion``: remediation hint provided by the operator, if any.
+    - ``fields``: remaining typed attributes of the root cause frame.
+    - ``chain``: list of :class:`OperatorFrame` the error passed through, from
+      the outermost operator down to the root cause.
+
+    For legacy flat-string errors these attributes stay ``None``/empty and the
+    behavior is unchanged.
+    """
 
     def __init__(self, msg=""):
-        message_parts = msg.rsplit('<-', maxsplit=1)
-        error_note = ""
-        if len(message_parts) == 1:
-            error_message = message_parts[0]
+        self.type = None
+        self.what = None
+        self.suggestion = None
+        self.fields = {}
+        self.chain = []
+
+        structured = _parse_structured_error(msg)
+        if structured is not None:
+            error_message, error_note = self._init_structured(structured)
         else:
-            error_note, error_message = message_parts
+            error_message, error_note = self._init_legacy(msg)
 
         Exception.__init__(self, error_message)
         if sys.version_info >= (3, 11): #add_note method is supported only in python >= 3.11
@@ -20,6 +65,48 @@ class DPFServerException(Exception):
             if not hasattr(self, "__notes__"): #if the system is python < 3.11 we custom our own notes property
                 self.__notes__ = []
             self.__notes__.append(error_note)
+
+    def _init_structured(self, data):
+        """Populate structured attributes and return the (message, note) pair."""
+        frames_raw = data.get("frames", {})
+        # Frames are keyed by string indices; "0" is the innermost root cause.
+        frames = [frames_raw[key] for key in sorted(frames_raw, key=int)]
+        root = frames[0] if frames else {}
+
+        self.type = root.get("type")
+        self.what = root.get("what", "")
+        self.suggestion = root.get("suggestion")
+        self.fields = {
+            key: value
+            for key, value in root.items()
+            if key not in ("type", "what", "suggestion")
+        }
+        # Operator frames, from the outermost operator down to the root cause.
+        self.chain = [
+            OperatorFrame(frame.get("operator_name"), frame.get("operator_id"))
+            for frame in reversed(frames)
+            if frame.get("type") == "opframe"
+        ]
+
+        error_message = self.what
+        if self.suggestion:
+            error_message = f"{self.what}\nSuggestion: {self.suggestion}"
+
+        if self.chain:
+            error_note = "Operator chain: " + " <- ".join(
+                f"{frame.name} ({frame.id})" for frame in self.chain
+            )
+        else:
+            error_note = ""
+        return error_message, error_note
+
+    def _init_legacy(self, msg):
+        """Split a legacy flat-string error into a (message, note) pair."""
+        message_parts = msg.rsplit('<-', maxsplit=1)
+        if len(message_parts) == 1:
+            return message_parts[0], ""
+        error_note, error_message = message_parts
+        return error_message, error_note
 
 
 class DPFServerNullObject(Exception):

--- a/src/ansys/dpf/gate/errors.py
+++ b/src/ansys/dpf/gate/errors.py
@@ -43,6 +43,34 @@ class DPFServerException(Exception):
 
     For legacy flat-string errors these attributes stay ``None``/empty and the
     behavior is unchanged.
+
+    Examples
+    --------
+    Catch a server error raised while evaluating an operator and inspect the
+    structured root cause:
+
+    >>> import ansys.dpf.core as dpf
+    >>> from ansys.dpf.core import operators as ops
+    >>> data_sources = dpf.DataSources("non_existing_file.rst")
+    >>> displacement = ops.result.displacement(data_sources=data_sources)
+    >>> try:  # doctest: +SKIP
+    ...     displacement.eval()
+    ... except dpf.errors.DPFServerException as error:
+    ...     # ``str(error)`` is a short, actionable message (root cause and,
+    ...     # when available, a remediation suggestion).
+    ...     print(str(error))
+    ...     # The following attributes are populated when the server reports a
+    ...     # structured error; otherwise they stay ``None``/empty.
+    ...     print(error.type)  # stable category, e.g. "file_not_found"
+    ...     print(error.suggestion)  # remediation hint, when the operator provides one
+    ...     print(error.fields)  # extra typed data, e.g. {"filepath": "..."}
+    ...     # ``chain`` lists the operators the error crossed, from the
+    ...     # outermost operator down to the root cause.
+    ...     for frame in error.chain:
+    ...         print(frame.name, frame.id)
+    ...     # Branch on the stable ``type`` to recover from a specific failure.
+    ...     if error.type == "file_not_found":
+    ...         pass  # e.g. prompt the user for a valid path and retry
     """
 
     def __init__(self, msg=""):

--- a/tests/test_server_errors.py
+++ b/tests/test_server_errors.py
@@ -53,6 +53,68 @@ def test_server_exception_from_workflow():
     assert exception.__notes__
 
 
+def test_server_exception_structure_from_operator():
+    """Trigger a real operator error and show how to handle the structured error.
+
+    The operator points at a non-existing result file, so the server raises a
+    failure while evaluating it.
+    """
+    ds = dpf.DataSources(r"dummy/file.rst")
+    op = ops.result.displacement(data_sources=ds)
+
+    with pytest.raises(errors.DPFServerException) as exception_info:
+        op.eval()
+
+    exception = exception_info.value
+
+    # A short, human-readable message is always available for display.
+    assert str(exception)
+
+    if exception.type is not None:
+        # Structured server error: the typed root cause is separated from the
+        # operator chain instead of being concatenated into one flat string.
+        assert exception.what
+        assert exception.what in str(exception)
+        # `fields` holds the root-cause typed attributes (e.g. a file path),
+        # `chain` lists the operators the error passed through.
+        assert isinstance(exception.fields, dict)
+        assert isinstance(exception.chain, list)
+        for frame in exception.chain:
+            assert frame.name  # the failing operator is reported through the chain
+        # Client code branches on the stable `type` to recover from a category,
+        # for example a missing input file:
+        if exception.type == "file_not_found":
+            assert "filepath" in exception.fields or exception.suggestion is not None
+    else:
+        # Legacy flat-string server: the operator chain is kept as a note.
+        assert exception.__notes__
+
+
+def test_server_exception_structure_from_workflow():
+    """Trigger a real workflow error and show how to identify the failing operator."""
+    op = dpf.operators.result.displacement(data_sources=dpf.DataSources("toto.rst"))
+
+    wf = dpf.Workflow()
+    wf.add_operator(op)
+    wf.set_output_name("out", op.outputs.fields_container)
+
+    with pytest.raises(errors.DPFServerException) as exception_info:
+        wf.get_output("out", output_type=dpf.FieldsContainer)
+
+    exception = exception_info.value
+    assert str(exception)
+
+    if exception.type is not None:
+        assert exception.what
+        assert exception.what in str(exception)
+        # In a chained workflow, `chain` identifies which operators the error
+        # crossed, from the outermost operator down to the root cause.
+        assert isinstance(exception.chain, list)
+        assert all(frame.name for frame in exception.chain)
+    else:
+        assert exception.__notes__
+
+
 def test_server_exception_legacy_flat_string():
     exception = errors.DPFServerException("V:751<-native::recursor:1930<-actual root cause")
     assert str(exception) == "actual root cause"

--- a/tests/test_server_errors.py
+++ b/tests/test_server_errors.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import pytest
+import json
 
 import ansys.dpf.core as dpf
 from ansys.dpf.core import errors, operators as ops
@@ -50,3 +51,93 @@ def test_server_exception_from_workflow():
     exception = exception_note.value
     assert hasattr(exception, "__notes__"), "The exception does not contain any note"
     assert exception.__notes__
+
+
+def test_server_exception_legacy_flat_string():
+    exception = errors.DPFServerException("V:751<-native::recursor:1930<-actual root cause")
+    assert str(exception) == "actual root cause"
+    assert exception.__notes__ == ["V:751<-native::recursor:1930"]
+    # Structured attributes stay empty for legacy errors.
+    assert exception.type is None
+    assert exception.what is None
+    assert exception.suggestion is None
+    assert exception.fields == {}
+    assert exception.chain == []
+
+
+def test_server_exception_legacy_no_chain():
+    exception = errors.DPFServerException("a plain error message")
+    assert str(exception) == "a plain error message"
+    assert exception.type is None
+
+
+def test_server_exception_structured():
+    payload = {
+        "depth": 3,
+        "frames": {
+            "2": {
+                "type": "kernel_clayer",
+                "what": 'Exception raised through CLayer function "Operator_run".',
+                "function_name": "Operator_run",
+            },
+            "1": {
+                "type": "opframe",
+                "what": 'Operator "U" (42) threw.',
+                "operator_name": "U",
+                "operator_id": 42,
+            },
+            "0": {
+                "type": "ansys.dpf.lsdyna.file_not_found",
+                "what": "d3plot file not found: /wrong/path/to/d3plot",
+                "filepath": "/wrong/path/to/d3plot",
+                "suggestion": "Check that the file path is correct and that the file is accessible.",
+            },
+        },
+    }
+    exception = errors.DPFServerException(json.dumps(payload))
+
+    assert exception.type == "ansys.dpf.lsdyna.file_not_found"
+    assert exception.what == "d3plot file not found: /wrong/path/to/d3plot"
+    assert exception.suggestion == "Check that the file path is correct and that the file is accessible."
+    assert exception.fields == {"filepath": "/wrong/path/to/d3plot"}
+    assert exception.chain == [errors.OperatorFrame("U", 42)]
+    # Root cause and suggestion form the user-facing message.
+    assert exception.what in str(exception)
+    assert exception.suggestion in str(exception)
+    # The operator chain is kept as a developer note.
+    assert exception.__notes__ == ["Operator chain: U (42)"]
+
+
+def test_server_exception_structured_multiple_operator_frames():
+    payload = {
+        "depth": 4,
+        "frames": {
+            "3": {"type": "kernel_clayer", "what": "clayer", "function_name": "Operator_run"},
+            "2": {"type": "opframe", "what": "outer", "operator_name": "V", "operator_id": 751},
+            "1": {
+                "type": "opframe",
+                "what": "inner",
+                "operator_name": "native::recursor",
+                "operator_id": 1930,
+            },
+            "0": {"type": "resource_exhaustion", "what": "Out-of-memory.", "resource": "heap_memory"},
+        },
+    }
+    exception = errors.DPFServerException(json.dumps(payload))
+
+    assert exception.type == "resource_exhaustion"
+    assert exception.suggestion is None
+    assert exception.fields == {"resource": "heap_memory"}
+    # Outermost operator first, down to the root cause.
+    assert exception.chain == [
+        errors.OperatorFrame("V", 751),
+        errors.OperatorFrame("native::recursor", 1930),
+    ]
+    assert str(exception) == "Out-of-memory."
+
+
+def test_server_exception_not_structured_json():
+    # Valid JSON but not a DPF structured error: treated as a plain message.
+    exception = errors.DPFServerException('{"unexpected": "payload"}')
+    assert exception.type is None
+    assert str(exception) == '{"unexpected": "payload"}'


### PR DESCRIPTION
This pull request enhances error handling for DPF server exceptions by adding support for structured (JSON) error messages, extracting detailed information from them, and improving test coverage to ensure robust behavior for both legacy and structured errors. The changes introduce a new `OperatorFrame` type, parsing logic for structured errors, and comprehensive tests for various error formats.

**Structured error handling improvements:**

* Added parsing of structured (JSON) error messages in `DPFServerException`, extracting attributes such as `type`, `what`, `suggestion`, `fields`, and the operator chain (`chain`), which is a list of `OperatorFrame` instances. This allows for richer error reporting and easier debugging. [[1]](diffhunk://#diff-6edb2731c312892e0beebc4d4808d530648227f02d049944078a851ec1fb3199R1-R59) [[2]](diffhunk://#diff-6edb2731c312892e0beebc4d4808d530648227f02d049944078a851ec1fb3199R69-R110)
* Introduced the `OperatorFrame` named tuple to represent operators that an error passed through, and made it available in both `ansys.dpf.gate.errors` and `ansys.dpf.core.errors`. [[1]](diffhunk://#diff-6edb2731c312892e0beebc4d4808d530648227f02d049944078a851ec1fb3199R1-R59) [[2]](diffhunk://#diff-9ccf3cfd9bb020bb186bb1cc5432945cb7e61a274c7a898bba5ddc9795b0ade4R31)

**Testing improvements:**

* Added comprehensive tests in `test_server_errors.py` to verify correct behavior for legacy flat-string errors, legacy errors without a chain, structured errors with and without operator frames, and non-structured JSON payloads. These tests ensure that both new and old error formats are handled as expected.
* Imported `json` in test files to support structured error testing.